### PR TITLE
Correction on pg_is_local_access

### DIFF
--- a/bin/pg_activity
+++ b/bin/pg_activity
@@ -339,7 +339,7 @@ system informations for a postgres process.
 """
 def pg_is_local_access():
     for p in psutil.process_iter():
-        if p.name == 'postgres':
+        if p.name == 'postgres' or p.name == 'postmaster':
             try:
                 proc = psutil.Process(p.pid)
                 proc.get_io_counters()


### PR DESCRIPTION
This pull request is a, really, small change in pg_is_local_access to also consider process name = 'postmaster', besides only 'postgres'. Which is the case depending how the cluster has been started.

I saw this problem when upgraded from this last version (it showed nothing that came from psutil anymore).

Thanks for this great tool and I hope this pull may help.
