### PR TITLE
Support defining the database to connect to.

### DIFF
--- a/bin/pg_activity
+++ b/bin/pg_activity
@@ -337,13 +337,13 @@ def get_pgpass(pgpass = None):
         return ret
     raise Exception("pgpass file not found")
 
-def pg_connect(host = 'localhost', port = 5432, user = 'postgres', password = None):
+def pg_connect(host = 'localhost', port = 5432, user = 'postgres', password = None, database = 'postgres'):
     """
     Connect to a PostgreSQL server and return
     cursor & connector.
     """
     conn = psycopg2.connect(
-            database = 'postgres',
+            database = database,
             host = host,
             port = port,
             user = user,
@@ -1378,9 +1378,13 @@ def main():
                 pass
         
         debug = options.debug
-        
+
+        database = os.environ.get('PGDATABASE')
+        if database is None:
+            database = 'postgres'
+
         try:
-            conn = pg_connect(host = options.host, port = options.port, user = options.username, password = password)
+            conn = pg_connect(host = options.host, port = options.port, user = options.username, password = password, database = database)
         except psycopg2.Error as e:
             at_exit_curses()
             sys.exit("FATAL: %s" % (clean_str(str(e),)))


### PR DESCRIPTION
One might not be allowed to connect to 'postgres' database remotely
(i.e. hba limitations).

Optionally the database to connect to can be read from the environment
variable PGDATABASE. If not set, 'postgres' is used as a default.

Would be nice though to set the database via a command line parameter.
