### PR TITLE
Sometimes crash with a TypeError in get_duration

### DIFF
--- a/bin/pg_activity
+++ b/bin/pg_activity
@@ -511,7 +511,7 @@ def get_duration(duration):
     Returns 0 if the given duration is negative
     else, returns the duration
     """
-    if float(duration) < 0:
+    if duration is None or float(duration) < 0:
         return 0
     return float(duration)
 


### PR DESCRIPTION
I've experienced some crashes with the following traceback:

Traceback (most recent call last):
  File "bin/pg_activity", line 1490, in main
    (disp_procs, new_procs) = poll(interval, conn, flag, indent, procs, pg_num_version, disp_procs)
  File "bin/pg_activity", line 750, in poll
    return poll_activities(interval, connector, flag, indent, process, pg_num_version, disp_proc)
  File "bin/pg_activity", line 890, in poll_activities
    procs.append({'pid':q['pid'], 'database': q['database'], 'client': q['client'], 'query': q['query'], 'duration': get_duration(q['duration']), 'wait': q['wait']})
  File "bin/pg_activity", line 515, in get_duration
    if float(duration) < 0:
TypeError: float() argument must be a string or a number
FATAL: float() argument must be a string or a number

This patch fixes the issue. 

Thanks for your time. 
