### PR TITLE
Fix issue with undefined `debug` variable

### DIFF
--- a/pg_activity
+++ b/pg_activity
@@ -250,10 +250,11 @@ server activity monitoring.")
             print(parser.format_help().strip())
             sys.exit(1)
 
+        debug = options.debug
+
         password = pg_connect(options, password=os.environ.get('PGPASSWORD'),
                               service=os.environ.get('PGSERVICE'))
 
-        debug = options.debug
         pg_version = PGAUI.data.pg_get_version()
         PGAUI.data.pg_get_num_version(pg_version)
         hostname = socket.gethostname()


### PR DESCRIPTION
If exception occurs during the connection to the database we refer to `debug` variable which is not defined yet. So we should define it before we connect to the database. Error message I got before fixing the issue:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pg_activity-1.5.0-py3.7.egg/EGG-INFO/scripts/pg_activity", line 254, in main
  File "/usr/local/lib/python3.7/site-packages/pg_activity-1.5.0-py3.7.egg/EGG-INFO/scripts/pg_activity", line 417, in pg_connect
  File "/usr/local/lib/python3.7/site-packages/pg_activity-1.5.0-py3.7.egg/pgactivity/Data.py", line 165, in pg_connect
Exception: Must be run with database superuser privileges.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/pg_activity", line 4, in <module>
    __import__('pkg_resources').run_script('pg-activity==1.5.0', 'pg_activity')
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1469, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python3.7/site-packages/pg_activity-1.5.0-py3.7.egg/EGG-INFO/scripts/pg_activity", line 440, in <module>
  File "/usr/local/lib/python3.7/site-packages/pg_activity-1.5.0-py3.7.egg/EGG-INFO/scripts/pg_activity", line 395, in main
UnboundLocalError: local variable 'debug' referenced before assignment
```