### PR TITLE
Introduce an explicit "duration mode"

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,4 +33,4 @@ pg_activity is an open project. Feel free to join us and improve this tool.
 * Matheus de Oliveira <matioli.matheus@gmail.com>
 * Mickaël Le Baillif <mickael.le.baillif@gmail.com>
 * Nicolas Dandrimont <olasd@softwareheritage.org>
-
+* Nils Hamerlinck <nils@trobz.com>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Options
         --verbose-mode=VERBOSE_MODE
                               Queries display mode. Values: 1-TRUNCATED,
                               2-FULL(default), 3-INDENTED
+        --duration-mode=DURATION_MODE
+                              Duration mode. Values: 1-QUERY(default),
+                              2-TRANSACTION, 3-BACKEND
 
 
     Display options, you can exclude some columns by using them :
@@ -91,6 +94,7 @@ Interactives commands
 | `c`       | Sort by CPU%, descending                                         |
 | `m`       | Sort by MEM%, descending                                         |
 | `t`       | Sort by TIME+, descending                                        |
+| `T`       | Change duration mode: query, transaction, backend                |
 | `Space`   | Pause on/off                                                     |
 | `v`       | Change queries display mode: full, indented, truncated           |
 | `UP/DOWN` | Scroll processes list                                            |

--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "PG_ACTIVITY 1"
-.TH PG_ACTIVITY 1 "2019-03-03" "pg_activity 1.5.0" "Command line tool for PostgreSQL server activity monitoring."
+.TH PG_ACTIVITY 1 "2020-02-14" "pg_activity 1.5.0" "Command line tool for PostgreSQL server activity monitoring."
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -197,6 +197,11 @@ as the user running the instance (or root) to show
 .IX Item "--verbose-mode=VERBOSE_MODE"
 .Vb 1
 \&        Queries display mode. Values: 1\-TRUNCATED, 2\-FULL(default), 3\-INDENTED
+.Ve
+.IP "\fB\-\-duration\-mode=DURATION_MODE\fR" 2
+.IX Item "--duration-mode=DURATION_MODE"
+.Vb 1
+\&        Duration mode. Values: 1\-QUERY(default), 2\-TRANSACTION, 3\-BACKEND
 .Ve
 .IP "\fB\-\-help\fR" 2
 .IX Item "--help"
@@ -324,7 +329,7 @@ as the user running the instance (or root) to show
 .IX Item "h Help page."
 .IP "\fBR\fR     Refresh." 2
 .IX Item "R Refresh."
-.IP "\fBR\fR     Refresh database size." 2
+.IP "\fBD\fR     Refresh database size." 2
 .IX Item "D Refresh database size."
 .PD
 .SH "NAVIGATION MODE"

--- a/docs/man/pg_activity.pod
+++ b/docs/man/pg_activity.pod
@@ -58,6 +58,10 @@ CPU, MEM, READ or WRITE columns and other system informations.
 
 	Queries display mode. Values: 1-TRUNCATED, 2-FULL(default), 3-INDENTED
 
+=item B<--duration-mode=DURATION_MODE>
+
+	Duration mode. Values: 1-QUERY(default), 2-TRANSACTION, 3-BACKEND
+
 =item B<--help>
 
 	Show this help message and exit.

--- a/pg_activity
+++ b/pg_activity
@@ -166,6 +166,14 @@ server activity monitoring.")
                 metavar = 'VERBOSE_MODE',
                 choices = ['1', '2', '3'],
                 default = '2')
+            # --duration-mode
+            parser.add_option(
+                '--duration-mode',
+                dest = 'durationmode',
+                help = "Duration mode. Values: 1-QUERY(default), 2-TRANSACTION, 3-BACKEND",
+                metavar = 'DURATION_MODE',
+                choices = ['1', '2', '3'],
+                default = '1')
 
             group = OptionGroup(
                 parser,
@@ -265,6 +273,8 @@ server activity monitoring.")
         PGAUI.set_blocksize(int(options.blocksize))
         # verbose mode
         PGAUI.set_verbose_mode(int(options.verbosemode))
+        # duration mode
+        PGAUI.set_duration_mode(int(options.durationmode))
         # output
         PGAUI.set_output(options.output)
         # does pg_activity runing against local PG instance


### PR DESCRIPTION
- so far the content of the TIME column only reflected the duration of the query
- this PR introduces 2 other duration modes: transaction, backend
- press T to cycle through different duration modes
- active duration mode is shown in the top status bar:

![duration_mode](https://user-images.githubusercontent.com/511258/74583627-75cd5d00-4ffb-11ea-90e2-ac06f1cd55d0.png)
