### PR TITLE
Replace backend_type with is_background_worker

### DIFF
--- a/pgactivity/UI.py
+++ b/pgactivity/UI.py
@@ -2235,10 +2235,9 @@ class UI:
         dif = self.maxx - len(indent) - 1
 
         query = ''
-        if 'is_parallel_worker' in process and \
-                process['is_parallel_worker']:
-
+        if process.get('is_parallel_worker'):
             query += '\_ '
+
         if self.verbose_mode == PGTOP_TRUNCATE:
             query += process['query'][:dif]
             colno += self.__print_string(

--- a/pgactivity/UI.py
+++ b/pgactivity/UI.py
@@ -1411,7 +1411,7 @@ class UI:
                         'duration': self.data.get_duration(proc.duration),
                         'wait': proc.wait,
                         'io_wait': proc.get_extra('io_wait'),
-                        'backend_type': proc.get_extra('backend_type')
+                        'is_parallel_worker': proc.get_extra('is_parallel_worker')
                     })
 
                 except psutil.NoSuchProcess:
@@ -2235,8 +2235,8 @@ class UI:
         dif = self.maxx - len(indent) - 1
 
         query = ''
-        if 'backend_type' in process and \
-                process['backend_type'] == 'background worker':
+        if 'is_parallel_worker' in process and \
+                process['is_parallel_worker']:
 
             query += '\_ '
         if self.verbose_mode == PGTOP_TRUNCATE:


### PR DESCRIPTION
* This commit attempts to solve the issue : #130 [1].
* PoWA has a bug where `backend_type` is not correctly filled [2]. it
  was fixed but it's not in the stable version yet.
* Since [3], we queried for the `backend_type` and filtered
  `parallel workers` in the Python code. The test is now done in
  SQL,  which avoids the problems all together.
* The `parallel worker` detection was not working for pg 11+ because
  it uses the 'parallel worker' backend_type. It's now fixed.

[1] https://github.com/dalibo/pg_activity/issues/130
[2] https://github.com/powa-team/powa-archivist/pull/20
[3] https://github.com/dalibo/pg_activity/commit/6a180d86139d68a728946997996f346cc880888e