### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/pg_activity
+++ b/pg_activity
@@ -27,7 +27,7 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 from __future__ import print_function
 
-PGTOP_VERSION = "1.5.0"
+PGTOP_VERSION = "1.6.0"
 
 import os
 import sys


### PR DESCRIPTION
This is a proposition for the release notes :                                             
                                                                                
Change log:                                                                     
                                                                                
* Add the --min-duration flag to only show laggy queries (@kmoppel)             
* Add the --duration-mode and the shortcut (T) to choose the duration modes:       
  query, transaction, backend (@nilshamerlinck )                                
* Move to dalibo labs (@daamien)                                                
* Expand current 1-3s refresh interval to 0.5-5s (@kmoppel)                     
* Add the refresh dbsize interative action (D) (Fabio Renato Geiss)             
* Add --verbose-mode in man page (@julmon)                                      
                                                                                
Bug fixes:                                                                      
                                                                                
* Fix #130: change the handling of parallel workers and fix a problem with PoWA 
  (fix: @blogh @julmon, report: @debnet)                                        
* Fix #118: psycopg2 has to be installed manually before pg_activity (fix:         
  @blogh, report: @kmoppel)                                                     
* Fix issue with undefined `debug` variable (@pensnarik)                        
* Fix #119: some columns have been shifted in Waiting / Blocking views (fix:       
  @julmon, report: @kmoppel)                                                    
* Fix #113: Do not try to display query duration if not there (fix: @julmon,       
  report: @pmpetit)          