### PR TITLE
Fix the display of the state of transaction for PostgreSQL < 9.1

### DIFF
--- a/pgactivity/Data.py
+++ b/pgactivity/Data.py
@@ -317,12 +317,22 @@ class Data:
         """
         Get total of active connections.
         """
-        query = """
-        SELECT
-            COUNT(*) as active_connections
-        FROM pg_stat_activity
-        WHERE state = 'active'
-        """
+
+        if self.pg_num_version <= 90100:
+            # prior to PostgreSQL 9.1, there was no state column
+            query = """
+    SELECT
+        COUNT(*) as active_connections
+    FROM pg_stat_activity
+    WHERE query NOT LIKE '<IDLE>%'
+            """
+        else:
+            query = """
+    SELECT
+        COUNT(*) as active_connections
+    FROM pg_stat_activity
+    WHERE state = 'active'
+            """
 
         cur = self.pg_conn.cursor()
         cur.execute(query,)


### PR DESCRIPTION
The state column appeared in PG 9.2 along with the change "current_query" => "query".

Before the current_query column contained the following for non active queries :
* `<IDLE> in transaction (aborted)`
* `<IDLE> in transaction`
* `<IDLE>`