### PR TITLE
Connection string

### DIFF
--- a/pg_activity
+++ b/pg_activity
@@ -55,6 +55,12 @@ def get_parser():
     parser = ModifiedOptionParser(
         add_help_option = False,
         version = "%prog " + __version__,
+        usage = "%prog [options] [connection string]",
+        epilog = "The connection string can be in the form of a list of \
+Key/Value parameters or an URI as described in the PostgreSQL documentation. \
+The parsing is delegated to the libpq: different versions of the client library \
+may support different formats or parameters (for example, connection URIs are \
+only supported from libpq 9.2)",
         description = "htop like application for PostgreSQL \
 server activity monitoring.")
     # -U / --username
@@ -249,7 +255,14 @@ if __name__ == '__main__':
         sys.exit("FATAL: Platform not supported.")
     try:
         parser = get_parser()
-        (options, _) = parser.parse_args()
+        (options, args) = parser.parse_args()
+        if len(args) == 1:
+            dsn = args[0]
+        elif len(args) > 1:
+            raise OptionParsingError("at most one argument is expected")
+        else:
+            dsn = ''
+
     except OptionParsingError as err:
         print('pg_activity: error: %s' % err.msg)
         print('Try "pg_activity --help" for more information.')
@@ -259,11 +272,9 @@ if __name__ == '__main__':
         sys.exit(1)
 
     hostname = socket.gethostname()
-    host = types.Host(
+    host = types.Host.from_options(
+        options,
+        dsn,
         hostname,
-        options.username,
-        options.host,
-        options.port,
-        options.dbname,
     )
-    ui.main(host, options)
+    ui.main(host, options, dsn)

--- a/pg_activity
+++ b/pg_activity
@@ -26,11 +26,12 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 import os
+import socket
 import sys
 from optparse import OptionParser, OptionGroup
 import getpass
 
-from pgactivity import __version__, ui
+from pgactivity import __version__, types, ui
 
 
 # Customized OptionParser
@@ -257,4 +258,12 @@ if __name__ == '__main__':
         print(parser.format_help().strip())
         sys.exit(1)
 
-    ui.main(options)
+    hostname = socket.gethostname()
+    host = types.Host(
+        hostname,
+        options.username,
+        options.host,
+        options.port,
+        options.dbname,
+    )
+    ui.main(host, options)

--- a/pg_activity
+++ b/pg_activity
@@ -31,6 +31,8 @@ import sys
 from optparse import OptionParser, OptionGroup
 import getpass
 
+import psycopg2
+
 from pgactivity import __version__, types, ui
 
 
@@ -249,6 +251,12 @@ server activity monitoring.")
     return parser
 
 
+def exit(msg: str) -> None:
+    print('pg_activity: error: %s' % msg)
+    print('Try "pg_activity --help" for more information.')
+    sys.exit(1)
+
+
 # Call the main function
 if __name__ == '__main__':
     if os.name != 'posix':
@@ -264,17 +272,18 @@ if __name__ == '__main__':
             dsn = ''
 
     except OptionParsingError as err:
-        print('pg_activity: error: %s' % err.msg)
-        print('Try "pg_activity --help" for more information.')
-        sys.exit(1)
+        exit(err.msg)
     if options.help:
         print(parser.format_help().strip())
         sys.exit(1)
 
     hostname = socket.gethostname()
-    host = types.Host.from_options(
-        options,
-        dsn,
-        hostname,
-    )
+    try:
+        host = types.Host.from_options(
+            options,
+            dsn,
+            hostname,
+        )
+    except psycopg2.ProgrammingError as err:
+        exit(err)
     ui.main(host, options, dsn)

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -125,6 +125,7 @@ class Data:
         database: str = "postgres",
         rds_mode: bool = False,
         service: Optional[str] = None,
+        dsn: str = "",
     ) -> "Data":
         """Create an instance by connecting to a PostgreSQL server."""
         pg_conn = None
@@ -134,6 +135,11 @@ class Data:
                 if service is not None:
                     pg_conn = psycopg2.connect(
                         service=service,
+                        cursor_factory=psycopg2.extras.DictCursor,
+                    )
+                elif dsn:
+                    pg_conn = psycopg2.connect(
+                        dsn=dsn,
                         cursor_factory=psycopg2.extras.DictCursor,
                     )
                 else:
@@ -151,6 +157,11 @@ class Data:
             if service is not None:
                 pg_conn = psycopg2.connect(
                     service=service,
+                    cursor_factory=psycopg2.extras.DictCursor,
+                )
+            elif dsn:
+                pg_conn = psycopg2.connect(
+                    dsn=dsn,
                     cursor_factory=psycopg2.extras.DictCursor,
                 )
             else:
@@ -850,6 +861,7 @@ class Data:
 
 def pg_connect(
     options: optparse.Values,
+    dsn: str,
     password: Optional[str] = None,
     service: Optional[str] = None,
     exit_on_failed: bool = True,
@@ -859,6 +871,7 @@ def pg_connect(
     for nb_try in range(2):
         try:
             data = Data.pg_connect(
+                dsn=dsn,
                 host=options.host,
                 port=options.port,
                 user=options.username,

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -680,7 +680,6 @@ class UI:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Host:
-    pg_version: str
     hostname: str
     user: str
     host: str

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -712,7 +712,6 @@ class Host:
         Host(hostname='test', user='toto', host='localhost', port=5432, dbname='bench')
         """
 
-        # FIXME : gerer l'erreur de DSN et tester avec pg <= 9.2
         pdsn = parse_dsn(dsn)
 
         return cls(

--- a/pgactivity/ui.py
+++ b/pgactivity/ui.py
@@ -31,7 +31,6 @@ def main(
     fs_blocksize = options.blocksize
 
     host = types.Host(
-        data.pg_version,
         hostname,
         options.username,
         options.host,
@@ -232,6 +231,7 @@ def main(
                     ui,
                     host=host,
                     dbinfo=dbinfo,
+                    pg_version=data.pg_version,
                     tps=tps,
                     active_connections=active_connections,
                     activity_stats=activity_stats,

--- a/pgactivity/ui.py
+++ b/pgactivity/ui.py
@@ -13,6 +13,7 @@ from .data import pg_connect
 def main(
     host: types.Host,
     options: optparse.Values,
+    dsn: str,
     *,
     term: Optional[Terminal] = None,
     render_header: bool = True,
@@ -22,6 +23,7 @@ def main(
 ) -> None:
     data = pg_connect(
         options,
+        dsn,
         password=os.environ.get("PGPASSWORD"),
         service=os.environ.get("PGSERVICE"),
         min_duration=options.minduration,

--- a/pgactivity/ui.py
+++ b/pgactivity/ui.py
@@ -1,6 +1,5 @@
 import optparse
 import os
-import socket
 import time
 from typing import Dict, List, Optional, cast
 
@@ -12,6 +11,7 @@ from .data import pg_connect
 
 
 def main(
+    host: types.Host,
     options: optparse.Values,
     *,
     term: Optional[Terminal] = None,
@@ -27,16 +27,7 @@ def main(
         min_duration=options.minduration,
     )
 
-    hostname = socket.gethostname()
     fs_blocksize = options.blocksize
-
-    host = types.Host(
-        hostname,
-        options.username,
-        options.host,
-        options.port,
-        options.dbname,
-    )
 
     is_local = data.pg_is_local() and data.pg_is_local_access()
 

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -180,6 +180,7 @@ def header(
     *,
     host: Host,
     dbinfo: DBInfo,
+    pg_version: str,
     tps: int,
     active_connections: int,
     system_info: Optional[SystemInfo] = None,
@@ -189,7 +190,7 @@ def header(
     yield (
         " - ".join(
             [
-                host.pg_version,
+                pg_version,
                 f"{term.bold}{host.hostname}{term.normal}",
                 f"{term.cyan}{pg_host}{term.normal}",
                 f"Ref.: {ui.refresh_time}s",
@@ -467,6 +468,7 @@ def screen(
     *,
     host: Host,
     dbinfo: DBInfo,
+    pg_version: str,
     tps: int,
     active_connections: int,
     activity_stats: ActivityStats,
@@ -494,6 +496,7 @@ def screen(
             ui,
             host=host,
             dbinfo=dbinfo,
+            pg_version=pg_version,
             tps=tps,
             active_connections=active_connections,
             system_info=system_info,

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -75,7 +75,7 @@ Default CLI options, passed to ui.main():
 ...         return ks
 ...
 ...     with patch.object(term, "inkey", new=inkey):
-...         ui.main(host, options, term=term,
+...         ui.main(host, options, "", term=term,
 ...                 render_header=render_header, render_footer=render_footer,
 ...                 width=width, wait_on_actions=1)
 ...

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -9,7 +9,7 @@ Functional tests for 'ui' module
 >>> import blessed
 >>> from blessed.keyboard import Keystroke
 
->>> from pgactivity import ui
+>>> from pgactivity import types, ui
 
 >>> postgres = getfixture("postgresql")
 
@@ -48,6 +48,13 @@ Default CLI options, passed to ui.main():
 >>> term.width, term.height
 (80, 25)
 
+>>> host = types.Host(
+...     "test",
+...     postgres.info.user,
+...     postgres.info.host,
+...     postgres.info.port,
+...     postgres.info.dbname,
+... )
 >>> def run_ui(options, keys, expected_timeouts=None,
 ...            render_header=True, render_footer=False,
 ...            width=200):
@@ -68,7 +75,7 @@ Default CLI options, passed to ui.main():
 ...         return ks
 ...
 ...     with patch.object(term, "inkey", new=inkey):
-...         ui.main(options, term=term,
+...         ui.main(host, options, term=term,
 ...                 render_header=render_header, render_footer=render_footer,
 ...                 width=width, wait_on_actions=1)
 ...
@@ -90,7 +97,7 @@ Force non-local mode and mock db size info
 No activity, first screen followed by help screen:
 
 >>> run_ui(options, ["h", "z", "q"])  # doctest: +ELLIPSIS
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT              state   Query
@@ -114,7 +121,7 @@ Mode
 <BLANKLINE>
 Press any key to exit.
 ------------------------------------------------------------------------------------------- sending key 'z' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT              state   Query
@@ -136,84 +143,84 @@ change query mode then quit:
 >>> expected_timeouts = [2.0, 1.0, 0.5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 >>> assert len(keys) == len(expected_timeouts)
 >>> run_ui(options, keys, expected_timeouts=expected_timeouts)  # doctest: +ELLIPSIS
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key '-' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key '-' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 0.5s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 0.5s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key '+' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key ' ' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key 'T' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key '3' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key 'r' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key ' ' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key 'T' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key 'c' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key '2' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
                                 WAITING QUERIES
 DATABASE                     USER           CLIENT  RELATION             TYPE             MODE              state   Query
 ------------------------------------------------------------------------------------------- sending key '1' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
 ------------------------------------------------------------------------------------------- sending key '3' --------------------------------------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 1s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
                                 BLOCKING QUERIES
 DATABASE                     USER           CLIENT  RELATION             TYPE             MODE              state   Query
@@ -292,7 +299,7 @@ Interactive mode:
 >>> keys = [key_down, 2, 3, 1, key_down, "C", "n", "K", "y",
 ...         key_down, " ", key_down, " ", "K", "y", "q"]
 >>> run_ui(options, keys, render_footer=True, width=140)  # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -302,7 +309,7 @@ PID    DATABASE                      state   Query
 ...    tests                        active   UPDATE t SET s = 'waiting'
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ---------------------------------------------------------- sending key 'KEY_DOWN' ----------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -312,21 +319,21 @@ PID    DATABASE                      state   Query
 ...    tests                        active   UPDATE t SET s = 'waiting'
 C Cancel current query     K Terminate current query  Space Tag/untag current qu Other Back to activities   q Quit                          
 ------------------------------------------------------------- sending key '2' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 WAITING QUERIES
 PID    DATABASE          RELATION             TYPE             MODE              state   Query
 ...    tests                 None    transactionid        ShareLock             active   UPDATE t SET s = 'waiting'
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ------------------------------------------------------------- sending key '3' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 BLOCKING QUERIES
 PID    DATABASE          RELATION             TYPE             MODE              state   Query
 ...    tests                 None    transactionid    ExclusiveLock      idle in trans   UPDATE t SET s = 'blocking'
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ------------------------------------------------------------- sending key '1' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -336,7 +343,7 @@ PID    DATABASE                      state   Query
 ...    tests                        active   UPDATE t SET s = 'waiting'
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ---------------------------------------------------------- sending key 'KEY_DOWN' ----------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -350,7 +357,7 @@ C Cancel current query     K Terminate current query  Space Tag/untag current qu
                                               │ Confirm cancel action on process  ...? (y/n) │                                              
                                               └──────────────────────────────────────────────┘                                              
 ------------------------------------------------------------- sending key 'n' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -364,7 +371,7 @@ C Cancel current query     K Terminate current query  Space Tag/untag current qu
                                             │ Confirm terminate action on process  ...? (y/n) │                                             
                                             └─────────────────────────────────────────────────┘                                             
 ------------------------------------------------------------- sending key 'y' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -373,7 +380,7 @@ PID    DATABASE                      state   Query
 ...    tests                        active   UPDATE t SET s = 'waiting'
                              Process ... terminated
 ---------------------------------------------------------- sending key 'KEY_DOWN' ----------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -382,7 +389,7 @@ PID    DATABASE                      state   Query
 ...    tests                        active   UPDATE t SET s = 'waiting'
                              Process ... terminated
 ------------------------------------------------------------- sending key ' ' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -391,7 +398,7 @@ PID    DATABASE                      state   Query
 ...    tests                        active   UPDATE t SET s = 'waiting'
 C Cancel current query     K Terminate current query  Space Tag/untag current qu Other Back to activities   q Quit                          
 ---------------------------------------------------------- sending key 'KEY_DOWN' ----------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -400,7 +407,7 @@ PID    DATABASE                      state   Query
 ...    tests                        active   UPDATE t SET s = 'waiting'
 C Cancel current query     K Terminate current query  Space Tag/untag current qu Other Back to activities   q Quit                          
 ------------------------------------------------------------- sending key ' ' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
@@ -413,7 +420,7 @@ C Cancel current query     K Terminate current query  Space Tag/untag current qu
                                         │ Confirm terminate action on processes ..., ...? (y/n)   │
                                         └─────────────────────────────────────────────────────────┘
 ------------------------------------------------------------- sending key 'y' --------------------------------------------------------------
-PostgreSQL ... - ... - postgres@127.0.0.1:.../tests - Ref.: 2s
+PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -63,20 +63,20 @@ Tests for header()
 
 Remote host:
 
->>> host = Host("PostgreSQL 9.6", "server", "pgadm", "server.prod.tld", 5433, "app")
+>>> host = Host("server", "pgadm", "server.prod.tld", 5433, "app")
 >>> dbinfo = DBInfo(10203040506070809, 9999)
 
->>> header(term, ui, host=host, dbinfo=dbinfo, tps=12, active_connections=0,
+>>> header(term, ui, host=host, dbinfo=dbinfo, pg_version="PostgreSQL 9.6", tps=12, active_connections=0,
 ...        width=200)
 PostgreSQL 9.6 - server - pgadm@server.prod.tld:5433/app - Ref.: 10s
  Size:         9.06P - 9.76K/s        | TPS:              12      | Active connections:               0      | Duration mode:     backend
->>> header(term, ui, host=host, dbinfo=dbinfo, tps=12, active_connections=0)
+>>> header(term, ui, host=host, dbinfo=dbinfo, pg_version="PostgreSQL 9.6", tps=12, active_connections=0)
 PostgreSQL 9.6 - server - pgadm@server.prod.tld:5433/app - Ref.: 10s
  Size:         9.06P - 9.76K/s        | TPS:              12      | Active
 
 Local host, with priviledged access:
 
->>> host = Host("PostgreSQL 13.1", "localhost", "tester", "host", 5432, "postgres")
+>>> host = Host("localhost", "tester", "host", 5432, "postgres")
 >>> dbinfo = DBInfo(123456789, 12)
 >>> vmem = MemoryInfo(total=6175825920, percent=42.5, used=2007146496)
 >>> swap = MemoryInfo(total=6312423424, used=2340, percent=0.0)
@@ -86,7 +86,7 @@ Local host, with priviledged access:
 >>> sysinfo = SystemInfo(vmem, swap, load, io_read, io_write, 12)
 
 >>> ui = UI.make(refresh_time=2, min_duration=1.2)
->>> header(term, ui, host=host, dbinfo=dbinfo, tps=1, active_connections=79,
+>>> header(term, ui, host=host, dbinfo=dbinfo, pg_version="PostgreSQL 13.1", tps=1, active_connections=79,
 ...        system_info=sysinfo, width=150)
 PostgreSQL 13.1 - localhost - tester@host:5432/postgres - Ref.: 2s - Min. duration: 1.2s
  Size:       117.74M - 12B/s          | TPS:               1      | Active connections:              79      | Duration mode:       query
@@ -364,7 +364,7 @@ Tests for screen()
 
 >>> processes3 = [processes1[0], processes1[2]]
 
->>> host = Host("PostgreSQL 13", "testhost", "pgadm", "server.prod.tld", 5433, "app")
+>>> host = Host("testhost", "pgadm", "server.prod.tld", 5433, "app")
 >>> dbinfo = DBInfo(10203040506070809, 9999)
 >>> vmem = MemoryInfo(total=4_220_876_001, percent=2.5, used=1_001_232_608)
 >>> swap = MemoryInfo(total=6_312_423_424, used=2_340, percent=1.0)
@@ -387,6 +387,7 @@ Tests for screen()
 ...     ui,
 ...     host=host,
 ...     dbinfo=dbinfo,
+...     pg_version="PostgreSQL 13",
 ...     tps=5,
 ...     active_connections=7,
 ...     activity_stats=(SelectableProcesses(processes3), sysinfo),
@@ -410,6 +411,7 @@ F1/1 Running queries    F2/2 Waiting queries    F3/3 Blocking queries   Space Pa
 ...     ui,
 ...     host=host,
 ...     dbinfo=dbinfo,
+...     pg_version="PostgreSQL 13",
 ...     tps=5,
 ...     active_connections=7,
 ...     activity_stats=(SelectableProcesses(processes3[:-1]), sysinfo),


### PR DESCRIPTION
Add connection strings to address https://github.com/dalibo/pg_activity/issues/151 & https://github.com/dalibo/pg_activity/issues/147

The idea is to mimic psql behavior of allowing a connection string to be specified as argument of the script. In that case the information provided overrides the host, port, user and dbname options.

Two syntax are possible  (depending in the version of libpq). (https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)

```
pg_activity "host=/tmp port=5432 user=toto dbname=pgbench"
pg_activity "postgresql://toto@localhost:5432/bench"
```
I am not very fond of the argument thing, I would have preferred an option like --dsn or somehing. It's less ugly in my pov but it's done like that in psql.
 
Note: I also fixed the default value of dbname which was wrong. 