### PR TITLE
compat with old blessed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Options
         --rds                 Enable support for AWS RDS.
         --output=FILEPATH     Store running queries as CSV.
         --help                Show this help message and exit.
-        --debug               Enable debug mode for traceback tracking.
         --no-db-size          Skip total size of DB.
         --min-duration        Don't display queries with smaller than specified
                               duration (in seconds).

--- a/pg_activity
+++ b/pg_activity
@@ -117,13 +117,6 @@ server activity monitoring.")
         action = 'store_true',
         help = "Show this help message and exit.",
         default = False)
-    # --debug
-    parser.add_option(
-        '--debug',
-        dest = 'debug',
-        action = 'store_true',
-        help = "Enable debug mode for traceback tracking.",
-        default = False)
     # --no-db-size
     parser.add_option(
         '--no-db-size',

--- a/pgactivity/compat.py
+++ b/pgactivity/compat.py
@@ -1,0 +1,16 @@
+import blessed
+
+
+BLESSED_VERSION = tuple(int(x) for x in blessed.__version__.split(".", 2)[:2])
+
+
+if BLESSED_VERSION < (1, 17):
+
+    def link(term: blessed.Terminal, url: str, text: str, url_id: str = "") -> str:
+        return url
+
+
+else:
+
+    def link(term: blessed.Terminal, url: str, text: str, url_id: str = "") -> str:
+        return term.link(url, text, url_id=url_id)  # type: ignore

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -16,6 +16,7 @@ from typing import (
 from blessed import Terminal
 from blessed.formatters import FormattingString
 
+from .compat import link
 from .keys import (
     BINDINGS,
     EXIT_KEY,
@@ -148,7 +149,7 @@ def help(term: Terminal, version: str, is_local: bool) -> Iterable[str]:
     project_url = "https://github.com/dalibo/pg_activity"
     intro = dedent(
         f"""\
-    {term.bold_green}pg_activity {version} - {term.link(project_url, project_url)}
+    {term.bold_green}pg_activity {version} - {link(term, project_url, project_url)}
     {term.normal}Released under PostgreSQL License.
     """
     )

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -17,7 +17,6 @@ Default CLI options, passed to ui.main():
 >>> defaults = {
 ...     "blocksize": 4096,
 ...     "dbname": f"{postgres.info.dbname}",
-...     "debug": False,
 ...     "durationmode": "1",
 ...     "help": False,
 ...     "host": f"{postgres.info.host}",


### PR DESCRIPTION
* first commit drops `--debug` flag which is no longer handled
* second commit fixes a compatibility issue with old versions of blessed, as available in debian stable