### PR TITLE
Use conninfo to populate the Host value

### DIFF
--- a/pg_activity
+++ b/pg_activity
@@ -33,8 +33,8 @@ import getpass
 from optparse import OptionParser, OptionGroup
 from typing import NoReturn
 
-from blessed import Terminal
 import psycopg2
+from blessed import Terminal
 
 from pgactivity import __version__, data, types, ui
 
@@ -281,14 +281,14 @@ if __name__ == '__main__':
         min_duration=options.minduration,
     )
     hostname = socket.gethostname()
-    try:
-        host = types.Host.from_options(
-            options,
-            dsn,
-            hostname,
-        )
-    except psycopg2.ProgrammingError as err:
-        exit(err)
+    conninfo = dataobj.pg_conn.info
+    host = types.Host(
+        hostname,
+        conninfo.user,
+        conninfo.host,
+        int(conninfo.port),
+        conninfo.dbname,
+    )
 
     term = Terminal()
     while True:

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -1,5 +1,4 @@
 import enum
-import optparse
 from typing import (
     Any,
     Callable,
@@ -19,7 +18,6 @@ from typing import (
 
 import attr
 import psutil
-from psycopg2.extensions import parse_dsn
 
 from . import colors, utils
 
@@ -693,40 +691,6 @@ class Host:
     host: str
     port: int
     dbname: str
-
-    @classmethod
-    def from_options(
-        cls,
-        options: optparse.Values,
-        dsn: str,
-        hostname: str,
-    ) -> "Host":
-        """Build a host instance from options and dsn
-
-        >>> options = optparse.Values(
-        ...     defaults = {
-        ...         "username": "bob",
-        ...         "host": "test",
-        ...         "port": 5432,
-        ...         "dbname": "pg",
-        ... })
-        >>> Host.from_options(options, "", "test")
-        Host(hostname='test', user='bob', host='test', port=5432, dbname='pg')
-        >>> Host.from_options(options, "host=/tmp port=5432 user=toto dbname=pgbench", "test")
-        Host(hostname='test', user='toto', host='/tmp', port=5432, dbname='pgbench')
-        >>> Host.from_options(options, "postgresql://toto@localhost:5432/bench", "test")
-        Host(hostname='test', user='toto', host='localhost', port=5432, dbname='bench')
-        """
-
-        pdsn = parse_dsn(dsn)
-
-        return cls(
-            hostname,
-            pdsn.get("user", options.username),
-            pdsn.get("host", options.host),
-            int(pdsn.get("port", options.port)),
-            pdsn.get("dbname", options.dbname),
-        )
 
 
 @attr.s(auto_attribs=True, slots=True)


### PR DESCRIPTION
Follow-up on https://github.com/dalibo/pg_activity/pull/156#issuecomment-754658744, @blogh. 

The UI behaves slightly differently as it would now display the socket value (e.g. `/var/run/postgresql`) instead of `localhost` in the header line for local connection.