### PR TITLE
ship the console script as a setuptools entry point

### DIFF
--- a/pg_activity
+++ b/pg_activity
@@ -1,30 +1,5 @@
 #!/usr/bin/env python3
 
-"""
-pg_activity
-author: Julien Tachoires <julmon@gmail.com>
-license: PostgreSQL License
-
-Copyright (c) 2012 - 2019, Julien Tachoires
-Copyright (c) 2020, Dalibo
-
-Permission to use, copy, modify, and distribute this software and its
-documentation for any purpose, without fee, and without a written
-agreement is hereby granted, provided that the above copyright notice
-and this paragraph and the following two paragraphs appear in all copies.
-
-IN NO EVENT SHALL JULIEN TACHOIRES BE LIABLE TO ANY PARTY FOR DIRECT,
-INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
-PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
-EVEN IF JULIEN TACHOIRES HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-JULIEN TACHOIRES SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT
-NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS"
-BASIS, AND JULIEN TACHOIRES HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
-SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-"""
-
 import os
 import socket
 import sys

--- a/pgactivity/__main__.py
+++ b/pgactivity/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import socket
 import sys
@@ -10,7 +8,7 @@ from typing import NoReturn
 from blessed import Terminal
 from psycopg2.errors import OperationalError
 
-from pgactivity import __version__, data, types, ui
+from . import __version__, data, types, ui
 
 
 # Customized OptionParser
@@ -255,8 +253,7 @@ def exit(msg: str) -> None:
     sys.exit(1)
 
 
-# Call the main function
-if __name__ == "__main__":
+def main() -> None:
     if os.name != "posix":
         sys.exit("FATAL: Platform not supported.")
     try:

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -1,28 +1,3 @@
-"""
-pg_activity
-author: Julien Tachoires <julmon@gmail.com>
-license: PostgreSQL License
-
-Copyright (c) 2012 - 2019, Julien Tachoires
-Copyright (c) 2020, Dalibo
-
-Permission to use, copy, modify, and distribute this software and its
-documentation for any purpose, without fee, and without a written
-agreement is hereby granted, provided that the above copyright notice
-and this paragraph and the following two paragraphs appear in all copies.
-
-IN NO EVENT SHALL JULIEN TACHOIRES BE LIABLE TO ANY PARTY FOR DIRECT,
-INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
-PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
-EVEN IF JULIEN TACHOIRES HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-JULIEN TACHOIRES SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT
-NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS"
-BASIS, AND JULIEN TACHOIRES HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
-SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-"""
-
 import getpass
 import optparse
 import re

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-include = '/(pg_activity|\.pyi?)$'
+include = '\.pyi?$'
 exclude = '''
 (
   /(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     version=get_version(),
     author="Dalibo",
     author_email="contact@dalibo.com",
-    scripts=["pg_activity"],
     packages=find_packages("."),
     include_package_data=True,
     url="https://github.com/dalibo/pg_activity",
@@ -61,4 +60,9 @@ setup(
         ],
     },
     data_files=data_files,
+    entry_points={
+        "console_scripts": [
+            "pg_activity=pgactivity.cli:main",
+        ],
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,10 @@ deps =
     flake8
 commands =
     black --check --diff {toxinidir}
-    flake8 {toxinidir} {toxinidir}/pg_activity
+    flake8 {toxinidir}
 
 [testenv:mypy]
 deps =
     mypy
 commands =
-    mypy pg_activity pgactivity
+    mypy pgactivity


### PR DESCRIPTION
Also add the possiblity to run the program as `python -m pgactivity <options>`.
Also remove the copyright/license notice on top of some files, as it's already stated in license.txt file.

Fix #197.
Fix #196.