### PR TITLE
Fix version decoding for pg >= 10

### DIFF
--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -29,19 +29,21 @@ def pg_get_num_version(text_version: str) -> Tuple[str, int]:
     version()).
 
     >>> pg_get_num_version('PostgreSQL 11.9')
-    ('PostgreSQL 11.9', 110900)
+    ('PostgreSQL 11.9', 110009)
     >>> pg_get_num_version('EnterpriseDB 11.9 (Debian 11.9-0+deb10u1)')
-    ('EnterpriseDB 11.9', 110900)
+    ('EnterpriseDB 11.9', 110009)
     >>> pg_get_num_version("PostgreSQL 9.3.24 on x86_64-pc-linux-gnu (Debian 9.3.24-1.pgdg80+1), compiled by gcc (Debian 4.9.2-10+deb8u1) 4.9.2, 64-bit")
     ('PostgreSQL 9.3.24', 90324)
-    >>> pg_get_num_version("PostgreSQL 9.1.24 on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39), 64-bit")
-    ('PostgreSQL 9.1.24', 90124)
-    >>> pg_get_num_dev_version("PostgreSQL 14devel on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
+    >>> pg_get_num_version("PostgreSQL 9.1.4 on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39), 64-bit")
+    ('PostgreSQL 9.1.4', 90104)
+    >>> pg_get_num_version("PostgreSQL 14devel on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
     ('PostgreSQL 14devel', 140000)
     >>> pg_get_num_version("PostgreSQL 13beta1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
     ('PostgreSQL 13beta1', 130000)
     >>> pg_get_num_version("PostgreSQL 13rc1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
     ('PostgreSQL 13rc1', 130000)
+    >>> pg_get_num_version("PostgreSQL 9.6rc1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
+    ('PostgreSQL 9.6rc1', 90600)
     """
     res = re.match(
         r"^(PostgreSQL|EnterpriseDB) ([0-9]+)\.([0-9]+)(?:\.([0-9]+))?",
@@ -49,17 +51,16 @@ def pg_get_num_version(text_version: str) -> Tuple[str, int]:
     )
     if res is not None:
         rmatch = res.group(2)
-        if int(res.group(3)) < 10:
-            rmatch += "0"
-        rmatch += res.group(3)
-        if res.group(4) is not None:
-            if int(res.group(4)) < 10:
-                rmatch += "0"
-            rmatch += res.group(4)
+        if int(res.group(2)) < 10:
+            rmatch += res.group(3).rjust(2, "0")
+            if res.group(4) is not None:
+                rmatch += res.group(4).rjust(2, "0")
+            else:
+                return pg_get_num_dev_version(text_version)
         else:
-            rmatch += "00"
-        pg_version = str(res.group(0))
+            rmatch += res.group(3).rjust(4, "0")
         pg_num_version = int(rmatch)
+        pg_version = str(res.group(0))
         return pg_version, pg_num_version
     return pg_get_num_dev_version(text_version)
 
@@ -70,10 +71,12 @@ def pg_get_num_dev_version(text_version: str) -> Tuple[str, int]:
 
     >>> pg_get_num_dev_version("PostgreSQL 14devel on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
     ('PostgreSQL 14devel', 140000)
-    >>> pg_get_num_version("PostgreSQL 13beta1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
+    >>> pg_get_num_dev_version("PostgreSQL 13beta1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
     ('PostgreSQL 13beta1', 130000)
-    >>> pg_get_num_version("PostgreSQL 13rc1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
+    >>> pg_get_num_dev_version("PostgreSQL 13rc1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
     ('PostgreSQL 13rc1', 130000)
+    >>> pg_get_num_dev_version("PostgreSQL 9.6rc1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit")
+    ('PostgreSQL 9.6rc1', 90600)
     """
     res = re.match(
         r"^(PostgreSQL|EnterpriseDB) ([0-9]+)(?:\.([0-9]+))?(devel|beta[0-9]+|rc[0-9]+)",
@@ -83,14 +86,11 @@ def pg_get_num_dev_version(text_version: str) -> Tuple[str, int]:
         raise Exception(f"Undefined PostgreSQL version: {text_version}")
     rmatch = res.group(2)
     if res.group(3) is not None:
-        if int(res.group(3)) < 10:
-            rmatch += "0"
-        rmatch += res.group(3)
+        rmatch += res.group(3).rjust(2, "0") + "00"
     else:
-        rmatch += "00"
-    rmatch += "00"
-    pg_version = str(res.group(0))
+        rmatch += "0000"
     pg_num_version = int(rmatch)
+    pg_version = str(res.group(0))
     return pg_version, pg_num_version
 
 


### PR DESCRIPTION
* Fix version decoding for version >= 10 as reported in issue 199
* Fix a bug with devel version < 10
* Fix tests