### PR TITLE
Set pytest default capture mode to "fd"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules
+addopts = --capture=fd --doctest-modules


### PR DESCRIPTION
Some of our doctest expects this (this is the default for me, but
maybe not for everyone). We can still use "-s/--capture=no" to override
this.

See #201 