### PR TITLE
Display pg_stat_activity's wait_event when available

### DIFF
--- a/pgactivity/activities.py
+++ b/pgactivity/activities.py
@@ -161,7 +161,7 @@ def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T
     ...         state="idle in transaction",
     ...         query="UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;",
     ...         duration=0.1,
-    ...         wait=False,
+    ...         wait="ClientRead",
     ...         io_wait=False,
     ...         is_parallel_worker=False,
     ...     ),

--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -9,10 +9,7 @@ SELECT
           ELSE pg_stat_activity.client_addr::TEXT
       END AS client,
       EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      CASE WHEN pg_stat_activity.wait_event_type IN ('LWLock', 'Lock', 'BufferPin')
-          THEN true
-          ELSE false
-      END AS wait,
+      pg_stat_activity.wait_event as wait,
       pg_stat_activity.usename AS user,
       pg_stat_activity.state AS state,
       pg_stat_activity.query AS query,

--- a/pgactivity/queries/get_pg_activity_post_110000.sql
+++ b/pgactivity/queries/get_pg_activity_post_110000.sql
@@ -8,10 +8,7 @@ SELECT
           ELSE pg_stat_activity.client_addr::TEXT
       END AS client,
       EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      CASE WHEN pg_stat_activity.wait_event_type IN ('LWLock', 'Lock', 'BufferPin')
-          THEN true
-	  ELSE false
-      END AS wait,
+      pg_stat_activity.wait_event AS wait,
       pg_stat_activity.usename AS user,
       pg_stat_activity.state AS state,
       pg_stat_activity.query AS query,

--- a/pgactivity/queries/get_pg_activity_post_90600.sql
+++ b/pgactivity/queries/get_pg_activity_post_90600.sql
@@ -9,7 +9,7 @@ SELECT
           ELSE pg_stat_activity.client_addr::TEXT
       END AS client,
       EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      pg_stat_activity.wait_event IS NOT NULL AS wait,
+      pg_stat_activity.wait_event AS wait,
       pg_stat_activity.usename AS user,
       pg_stat_activity.state AS state,
       pg_stat_activity.query AS query,

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -372,10 +372,11 @@ class UI:
         if Flag.WAIT & flag:
             add_column(
                 key="wait",
-                name="W",
-                template_h="%2s ",
-                transform=utils.yn,
+                name="Waiting",
+                template_h="%16s ",
+                transform=utils.wait_status,
                 color_key=colors.wait,
+                max_width=16,
             )
         if Flag.WRITE & flag:
             add_column(
@@ -696,7 +697,7 @@ class BaseProcess:
 class RunningProcess(BaseProcess):
     """Process for a running query."""
 
-    wait: bool
+    wait: Union[bool, None, str]
     is_parallel_worker: bool
 
 

--- a/pgactivity/utils.py
+++ b/pgactivity/utils.py
@@ -1,7 +1,7 @@
 import functools
 import re
 from datetime import datetime, timedelta
-from typing import Any, IO, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, IO, Iterable, List, Mapping, Optional, Tuple, Union
 
 import attr
 import humanize
@@ -141,6 +141,25 @@ def format_duration(duration: Optional[float]) -> Tuple[str, str]:
         color = "time_red"
 
     return ctime, color
+
+
+def wait_status(value: Union[None, bool, str]) -> str:
+    """Display the waiting status of query.
+
+    >>> wait_status(None)
+    ''
+    >>> wait_status(False)
+    'N'
+    >>> wait_status(True)
+    'Y'
+    >>> wait_status("MultiXactTruncationLock")
+    'MultiXactTruncationLock'
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return yn(value)
+    return ""
 
 
 def short_state(state: str) -> str:

--- a/tests/data/local-processes-input.json
+++ b/tests/data/local-processes-input.json
@@ -100,7 +100,7 @@
             "read": null,
             "state": "active",
             "user": "postgres",
-            "wait": false,
+            "wait": null,
             "write": null
         },
         "6223": {
@@ -253,7 +253,7 @@
             "read": null,
             "state": "active",
             "user": "postgres",
-            "wait": true,
+            "wait": "ClientRead",
             "write": null
         },
         "6226": {
@@ -304,7 +304,7 @@
             "read": null,
             "state": "active",
             "user": "postgres",
-            "wait": true,
+            "wait": "LogicalRepWorkerLock",
             "write": null
         },
         "6227": {

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -124,7 +124,7 @@ PID    DATABASE                      APP           CLIENT  RELATION             
 
 >>> ui.evolve(query_mode=QueryMode.activities)
 >>> columns_header(term, ui, width=150)
-PID    DATABASE                      APP           CLIENT  W              state   Query
+PID    DATABASE                      APP           CLIENT          Waiting              state   Query
 
 
 Tests for processes_rows()
@@ -161,7 +161,7 @@ Tests for processes_rows()
 ...         state="active",
 ...         query="UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;",
 ...         duration=0.000413,
-...         wait=False,
+...         wait=None,
 ...         io_wait=True,
 ...         is_parallel_worker=True,
 ...     ),
@@ -178,7 +178,7 @@ Tests for processes_rows()
 ...         state="active",
 ...         query="SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date > CURRENT_DATE - INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;",
 ...         duration=1234,
-...         wait=True,
+...         wait="BackendRandomLock",
 ...         io_wait=False,
 ...         is_parallel_worker=False,
 ...     ),
@@ -232,10 +232,10 @@ HAVING sum(p.price * s.units) > 5000;
 Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 (TODO: this is buggy, the first line should be wrapped as well if too long)
 >>> processes_rows(term, ui, SelectableProcesses(processes1), width=250)
-6239   pgbench                   pgbench         postgres            local    0.1  1.0       7B      12B  0.000000  N    N      idle in trans   UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
-6228   pgbench                   pgbench         postgres            local    0.2  1.0       0B    1.08M  0.000413  N    Y             active   \_ UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;
-1234   business               accounting              bob            local    2.4  1.0    9.42M    1.21K  20:34.00  Y    N             active   SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date > CURRENT_DATE
-- INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;
+6239   pgbench                   pgbench         postgres            local    0.1  1.0       7B      12B  0.000000                N    N      idle in trans   UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
+6228   pgbench                   pgbench         postgres            local    0.2  1.0       0B    1.08M  0.000413                     Y             active   \_ UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;
+1234   business               accounting              bob            local    2.4  1.0    9.42M    1.21K  20:34.00 BackendRandomLoc    N             active   SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date
+> CURRENT_DATE - INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;
 
 >>> ui = UI.make(flag=Flag.PID|Flag.DATABASE,
 ...              verbose_mode=QueryDisplayMode.truncate)
@@ -321,7 +321,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         state="active",
 ...         query="UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;",
 ...         duration=0.000413,
-...         wait=False,
+...         wait=True,
 ...         is_parallel_worker=True,
 ...     ),
 ...     RunningProcess(
@@ -333,18 +333,18 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         state="active",
 ...         query="SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date > CURRENT_DATE - INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;",
 ...         duration=1234,
-...         wait=True,
+...         wait="clog",
 ...         is_parallel_worker=False,
 ...     ),
 ... ]
 >>> all_but_local_flags = Flag.PID|Flag.DATABASE|Flag.APPNAME|Flag.USER|Flag.CLIENT|Flag.TIME|Flag.WAIT
 >>> ui = UI.make(query_mode=QueryMode.activities,flag=all_but_local_flags)
 >>> processes_rows(term, ui, SelectableProcesses(processes1b), width=200)
-6239   pgbench                   pgbench         postgres            local  0.000000  N      idle in trans   UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
-6228   pgbench                      none         postgres            local  0.000413  N             active   \_ UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;
-1234   business               accounting              bob     192.168.0.47  20:34.00  Y             active   SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date
-> CURRENT_DATE - INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;
-
+6239   pgbench                   pgbench         postgres            local  0.000000                N      idle in trans   UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
+6228   pgbench                      none         postgres            local  0.000413                Y             active   \_ UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid =
+7289374;
+1234   business               accounting              bob     192.168.0.47  20:34.00             clog             active   SELECT product_id, p.name FROM products p LEFT JOIN sales s USING
+(product_id) WHERE s.date > CURRENT_DATE - INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;
 
 
 Tests for footer_*()


### PR DESCRIPTION
## About pg_stat_activity's wait_event

* Before postgres 9.6, there's no `wait_event` nor `wait_event_type` column
* In postgres 9.6, `wait_event_type` values can be `LWLockNamed`, `LWLockTranche`, `Lock`, `BufferPin` and `wait_event` column is available.
* In postgres 10, new `wait_event_type` values: Activity, Extension, Client, IPC, Timeout, IO and many new `wait_event` (literal) values available.

Currently, in pg_activity:
*  prior to postgres 9.6, we simply use the `wait` (boolean) column of pg_stat_activity
* in postgres 9.6, we define the query as waiting if `wait_event IS NOT NULL`
* from version 10, we define the query as waiting when ` wait_event_type IN ('LWLock', 'Lock', 'BufferPin')`

(This seems inconsistent to me.)

## Proposed change

Always use `wait_event` when available and, if not NULL, declare the query as "waiting".

(See commit messages for extra details.)
