### PR TITLE
Fix encoding errors #149 > still WIP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,9 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install tox
         run: pip install tox
+      - name: Add fr_FR ISO-8859-1 for test purposes
+        run: |
+           sudo locale-gen fr_FR
+           sudo update-locale
       - name: Test
         run: tox -e py

--- a/pgactivity/queries/get_blocking_post_90200.sql
+++ b/pgactivity/queries/get_blocking_post_90200.sql
@@ -2,7 +2,7 @@
 SELECT
       pid,
       application_name,
-      datname AS database,
+      sq.datname AS database,
       usename AS user,
       client,
       relation,
@@ -10,16 +10,18 @@ SELECT
       locktype AS type,
       duration,
       state,
-      query,
+      convert_from(sq.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       waiting as wait
   FROM
       (
+      -- Transaction id lock
       SELECT
             blocking.pid,
             pg_stat_activity.application_name,
             pg_stat_activity.query,
             blocking.mode,
             pg_stat_activity.datname,
+            pg_stat_activity.datid,
             pg_stat_activity.usename,
             CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
@@ -48,12 +50,14 @@ SELECT
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
       UNION ALL
+      -- VirtualXid Lock
       SELECT
             blocking.pid,
             pg_stat_activity.application_name,
             pg_stat_activity.query,
             blocking.mode,
             pg_stat_activity.datname,
+            pg_stat_activity.datid,
             pg_stat_activity.usename,
             CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
@@ -82,12 +86,14 @@ SELECT
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
       UNION ALL
+      -- Relation Lock
       SELECT
             blocking.pid,
             pg_stat_activity.application_name,
             pg_stat_activity.query,
             blocking.mode,
             pg_stat_activity.datname,
+            pg_stat_activity.datid,
             pg_stat_activity.usename,
             CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
@@ -119,18 +125,20 @@ SELECT
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
       ) AS sq
+      LEFT OUTER JOIN pg_database b ON sq.datid = b.oid
 GROUP BY
       pid,
       application_name,
-      query,
+      database,
+      usename,
+      client,
+      relation,
       mode,
       locktype,
       duration,
-      datname,
-      usename,
-      client,
       state,
-      relation,
-      wait
+      query,
+      encoding,
+      wait_event
 ORDER BY
       duration DESC;

--- a/pgactivity/queries/get_blocking_post_90600.sql
+++ b/pgactivity/queries/get_blocking_post_90600.sql
@@ -2,7 +2,7 @@
 SELECT
       pid,
       application_name,
-      datname AS database,
+      sq.datname AS database,
       usename AS user,
       client,
       relation,
@@ -10,16 +10,18 @@ SELECT
       locktype AS type,
       duration,
       state,
-      query,
+      convert_from(sq.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       wait_event as wait
   FROM
       (
+      -- Transaction id lock
       SELECT
             blocking.pid,
             pg_stat_activity.application_name,
             pg_stat_activity.query,
             blocking.mode,
             pg_stat_activity.datname,
+            pg_stat_activity.datid,
             pg_stat_activity.usename,
             CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
@@ -48,12 +50,14 @@ SELECT
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
       UNION ALL
+      -- VirtualXid Lock
       SELECT
             blocking.pid,
             pg_stat_activity.application_name,
             pg_stat_activity.query,
             blocking.mode,
             pg_stat_activity.datname,
+            pg_stat_activity.datid,
             pg_stat_activity.usename,
             CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
@@ -82,12 +86,14 @@ SELECT
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
       UNION ALL
+      -- Relation Lock
       SELECT
             blocking.pid,
             pg_stat_activity.application_name,
             pg_stat_activity.query,
             blocking.mode,
             pg_stat_activity.datname,
+            pg_stat_activity.datid,
             pg_stat_activity.usename,
             CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
@@ -119,18 +125,20 @@ SELECT
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
       ) AS sq
+      LEFT OUTER JOIN pg_database b ON sq.datid = b.oid
 GROUP BY
       pid,
       application_name,
-      query,
+      database,
+      usename,
+      client,
+      relation,
       mode,
       locktype,
       duration,
-      datname,
-      usename,
-      client,
       state,
-      relation,
-      wait
+      query,
+      encoding,
+      wait_event
 ORDER BY
       duration DESC;

--- a/pgactivity/queries/get_pg_activity.sql
+++ b/pgactivity/queries/get_pg_activity.sql
@@ -1,28 +1,29 @@
 -- Get data from pg_activity before pg 9.2
 SELECT
-      pg_stat_activity.procpid AS pid,
+      a.procpid AS pid,
       '<unknown>' AS application_name,
-      pg_stat_activity.datname AS database,
-      CASE WHEN pg_stat_activity.client_addr IS NULL
+      a.datname AS database,
+      CASE WHEN a.client_addr IS NULL
           THEN 'local'
-          ELSE pg_stat_activity.client_addr::TEXT
+          ELSE a.client_addr::TEXT
       END AS client,
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      pg_stat_activity.waiting AS wait,
-      pg_stat_activity.usename AS user,
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
+      a.waiting AS wait,
+      a.usename AS user,
       CASE
-          WHEN pg_stat_activity.current_query = '<IDLE> in transaction (aborted)' THEN 'idle in transaction (aborted)'
-          WHEN pg_stat_activity.current_query = '<IDLE> in transaction' THEN 'idle in transaction'
-          WHEN pg_stat_activity.current_query = '<IDLE>' THEN 'idle'
+          WHEN a.current_query = '<IDLE> in transaction (aborted)' THEN 'idle in transaction (aborted)'
+          WHEN a.current_query = '<IDLE> in transaction' THEN 'idle in transaction'
+          WHEN a.current_query = '<IDLE>' THEN 'idle'
           ELSE 'active'
       END AS state,
       CASE
-          WHEN pg_stat_activity.current_query LIKE '<IDLE>%%' THEN NULL
-          ELSE pg_stat_activity.current_query
+          WHEN a.current_query LIKE '<IDLE>%%' THEN NULL
+          ELSE convert_from(a.current_query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
       END AS query,
       false AS is_parallel_worker
   FROM
-        pg_stat_activity
+        pg_stat_activity a
+        LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
       current_query <> '<IDLE>'
   AND procpid <> pg_backend_pid()
@@ -31,4 +32,4 @@ SELECT
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) DESC
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC

--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -1,23 +1,24 @@
 -- Get data from pg_activity from pg 10 to pg 11
 -- We assume a background_worker with a not null query is a parallel worker.
 SELECT
-      pg_stat_activity.pid AS pid,
-      pg_stat_activity.application_name AS application_name,
-      pg_stat_activity.datname AS database,
-      CASE WHEN pg_stat_activity.client_addr IS NULL
+      a.pid AS pid,
+      a.application_name AS application_name,
+      a.datname AS database,
+      CASE WHEN a.client_addr IS NULL
           THEN 'local'
-          ELSE pg_stat_activity.client_addr::TEXT
+          ELSE a.client_addr::TEXT
       END AS client,
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      pg_stat_activity.wait_event as wait,
-      pg_stat_activity.usename AS user,
-      pg_stat_activity.state AS state,
-      pg_stat_activity.query AS query,
-      (   pg_stat_activity.backend_type = 'background worker'
-          AND pg_stat_activity.query IS NOT NULL
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
+      a.wait_event as wait,
+      a.usename AS user,
+      a.state AS state,
+      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      (   a.backend_type = 'background worker'
+          AND a.query IS NOT NULL
       ) AS is_parallel_worker
   FROM
-      pg_stat_activity
+      pg_stat_activity a
+      LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
       state <> 'idle'
   AND pid <> pg_backend_pid()
@@ -26,4 +27,4 @@ SELECT
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/queries/get_pg_activity_post_110000.sql
+++ b/pgactivity/queries/get_pg_activity_post_110000.sql
@@ -1,26 +1,27 @@
 -- Get data from pg_activity since pg 11
 SELECT
-      pg_stat_activity.pid AS pid,
-      pg_stat_activity.application_name AS application_name,
-      pg_stat_activity.datname AS database,
-      CASE WHEN pg_stat_activity.client_addr IS NULL
+      a.pid AS pid,
+      a.application_name AS application_name,
+      a.datname AS database,
+      CASE WHEN a.client_addr IS NULL
           THEN 'local'
-          ELSE pg_stat_activity.client_addr::TEXT
+          ELSE a.client_addr::TEXT
       END AS client,
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      pg_stat_activity.wait_event AS wait,
-      pg_stat_activity.usename AS user,
-      pg_stat_activity.state AS state,
-      pg_stat_activity.query AS query,
-      pg_stat_activity.backend_type = 'parallel worker' AS is_parallel_worker
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
+      a.wait_event AS wait,
+      a.usename AS user,
+      a.state AS state,
+      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      a.backend_type = 'parallel worker' AS is_parallel_worker
  FROM
-      pg_stat_activity
+      pg_stat_activity a
+      LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
-      state <> 'idle'
-  AND pid <> pg_backend_pid()
+      a.state <> 'idle'
+  AND a.pid <> pg_catalog.pg_backend_pid()
   AND CASE WHEN %(min_duration)s = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/queries/get_pg_activity_post_90200.sql
+++ b/pgactivity/queries/get_pg_activity_post_90200.sql
@@ -1,20 +1,21 @@
 -- Get data from pg_activity from pg 9.2 to pg 9.5
 SELECT
-      pg_stat_activity.pid AS pid,
-      pg_stat_activity.application_name AS application_name,
-      pg_stat_activity.datname AS database,
-      CASE WHEN pg_stat_activity.client_addr IS NULL
+      a.pid AS pid,
+      a.application_name AS application_name,
+      a.datname AS database,
+      CASE WHEN a.client_addr IS NULL
           THEN 'local'
-          ELSE pg_stat_activity.client_addr::TEXT
+          ELSE a.client_addr::TEXT
       END AS client,
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      pg_stat_activity.waiting AS wait,
-      pg_stat_activity.usename AS user,
-      pg_stat_activity.state AS state,
-      pg_stat_activity.query AS query,
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
+      a.waiting AS wait,
+      a.usename AS user,
+      a.state AS state,
+      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       false AS is_parallel_worker
   FROM
-      pg_stat_activity
+      pg_stat_activity a
+      LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
       state <> 'idle'
   AND pid <> pg_backend_pid()
@@ -23,4 +24,4 @@ SELECT
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/queries/get_pg_activity_post_90600.sql
+++ b/pgactivity/queries/get_pg_activity_post_90600.sql
@@ -1,21 +1,22 @@
 -- Get data from pg_activity from pg 9.6 to 10
 -- In this versiosn there is no way to distinguish parallel workers from the rest
 SELECT
-      pg_stat_activity.pid AS pid,
-      pg_stat_activity.application_name AS application_name,
-      pg_stat_activity.datname AS database,
-      CASE WHEN pg_stat_activity.client_addr IS NULL
+      a.pid AS pid,
+      a.application_name AS application_name,
+      a.datname AS database,
+      CASE WHEN a.client_addr IS NULL
           THEN 'local'
-          ELSE pg_stat_activity.client_addr::TEXT
+          ELSE a.client_addr::TEXT
       END AS client,
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      pg_stat_activity.wait_event AS wait,
-      pg_stat_activity.usename AS user,
-      pg_stat_activity.state AS state,
-      pg_stat_activity.query AS query,
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
+      a.wait_event AS wait,
+      a.usename AS user,
+      a.state AS state,
+      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       false AS is_parallel_worker
   FROM
-      pg_stat_activity
+      pg_stat_activity a
+      LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
       state <> 'idle'
   AND pid <> pg_backend_pid()
@@ -24,4 +25,4 @@ SELECT
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/queries/get_waiting.sql
+++ b/pgactivity/queries/get_waiting.sql
@@ -2,35 +2,36 @@
 SELECT
       pg_locks.pid AS pid,
       '<unknown>' AS application_name,
-      pg_stat_activity.datname AS database,
-      pg_stat_activity.usename AS user,
-      CASE WHEN pg_stat_activity.client_addr IS NULL
+      a.datname AS database,
+      a.usename AS user,
+      CASE WHEN a.client_addr IS NULL
           THEN 'local'
-          ELSE pg_stat_activity.client_addr::TEXT
+          ELSE a.client_addr::TEXT
       END AS client,
       pg_locks.mode AS mode,
       pg_locks.locktype AS type,
       pg_locks.relation::regclass AS relation,
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       CASE
-          WHEN pg_stat_activity.current_query = '<IDLE> in transaction (aborted)' THEN 'idle in transaction (aborted)'
-          WHEN pg_stat_activity.current_query = '<IDLE> in transaction' THEN 'idle in transaction'
-          WHEN pg_stat_activity.current_query = '<IDLE>' THEN 'idle'
+          WHEN a.current_query = '<IDLE> in transaction (aborted)' THEN 'idle in transaction (aborted)'
+          WHEN a.current_query = '<IDLE> in transaction' THEN 'idle in transaction'
+          WHEN a.current_query = '<IDLE>' THEN 'idle'
           ELSE 'active'
       END AS state,
-      CASE WHEN pg_stat_activity.current_query LIKE '<IDLE>%%'
+      CASE WHEN a.current_query LIKE '<IDLE>%%'
           THEN NULL
-          ELSE pg_stat_activity.current_query
+          ELSE convert_from(a.current_query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
       END AS query
   FROM
       pg_catalog.pg_locks
-      JOIN pg_catalog.pg_stat_activity ON(pg_catalog.pg_locks.pid = pg_catalog.pg_stat_activity.procpid)
+      JOIN pg_catalog.pg_stat_activity a ON (pg_catalog.pg_locks.pid = a.procpid)
+      LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
       NOT pg_catalog.pg_locks.granted
-  AND pg_catalog.pg_stat_activity.procpid <> pg_backend_pid()
+  AND pg_catalog.a.procpid <> pg_backend_pid()
   AND CASE WHEN %(min_duration)s = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/queries/get_waiting_post_90200.sql
+++ b/pgactivity/queries/get_waiting_post_90200.sql
@@ -1,28 +1,29 @@
 -- Get waiting queries for versions >= 9.2
 SELECT
       pg_locks.pid AS pid,
-      pg_stat_activity.application_name AS application_name,
-      pg_stat_activity.datname AS database,
-      pg_stat_activity.usename AS user,
-      CASE WHEN pg_stat_activity.client_addr IS NULL
+      a.application_name AS application_name,
+      a.datname AS database,
+      a.usename AS user,
+      CASE WHEN a.client_addr IS NULL
           THEN 'local'
-          ELSE pg_stat_activity.client_addr::TEXT
+          ELSE a.client_addr::TEXT
       END AS client,
       pg_locks.mode AS mode,
       pg_locks.locktype AS type,
       pg_locks.relation::regclass AS relation,
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
-      pg_stat_activity.state as state,
-      pg_stat_activity.query AS query
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
+      a.state as state,
+      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query
   FROM
       pg_catalog.pg_locks
-      JOIN pg_catalog.pg_stat_activity ON(pg_catalog.pg_locks.pid = pg_catalog.pg_stat_activity.pid)
+      JOIN pg_catalog.pg_stat_activity a ON(pg_catalog.pg_locks.pid = a.pid)
+      LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
       NOT pg_catalog.pg_locks.granted
-  AND pg_catalog.pg_stat_activity.pid <> pg_backend_pid()
+  AND a.pid <> pg_backend_pid()
   AND CASE WHEN %(min_duration)s = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import pathlib
 import threading
+from typing import Optional
 
 import psycopg2
 import psycopg2.errors
@@ -21,9 +22,17 @@ def execute(postgresql):
 
     loop = asyncio.new_event_loop()
 
-    def execute(query: str, commit: bool = False, autocommit: bool = False) -> None:
+    def execute(
+        query: str,
+        commit: bool = False,
+        autocommit: bool = False,
+        dbname: Optional[str] = None,
+    ) -> None:
         def _execute() -> None:
-            conn = psycopg2.connect(**postgresql.info.dsn_parameters)
+            connection_parms = postgresql.info.dsn_parameters
+            if dbname:
+                connection_parms["dbname"] = dbname
+            conn = psycopg2.connect(**connection_parms)
             conn.autocommit = autocommit
             cnx.append(conn)
             with conn.cursor() as c:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+from psycopg2.errors import WrongObjectType
 
 from pgactivity.data import Data
 
@@ -112,6 +113,49 @@ def test_terminate_backend(postgresql, data):
 
 def test_pg_get_active_connections(data, execute):
     assert data.pg_get_active_connections() == 1
-    execute("select pg_sleep(1)")
+    execute("select pg_sleep(2)")
     time.sleep(1)
     assert data.pg_get_active_connections() == 2
+
+
+def test_encoding(postgresql, data, execute):
+    """Test for issue #149"""
+    postgresql.set_session(autocommit=True)
+    with postgresql.cursor() as cur:
+        # plateform specific locales (,Centos, Ubuntu)
+        for encoding in ["fr_FR.latin1", "fr_FR.88591", "fr_FR.8859-1"]:
+            try:
+                cur.execute(
+                    f"CREATE DATABASE latin1 ENCODING 'latin1' TEMPLATE template0 LC_COLLATE '{encoding}' LC_CTYPE '{encoding}'"
+                )
+            except WrongObjectType:
+                continue
+            else:
+                break
+
+    postgresql.set_session(autocommit=False)
+    execute("CREATE TABLE tbl(s text)", dbname="latin1", commit=True)
+    execute(
+        "INSERT INTO tbl(s) VALUES ('initilialized éléphant')",
+        dbname="latin1",
+        commit=True,
+    )
+    execute("UPDATE tbl SET s = 'blocking éléphant'", dbname="latin1")
+    execute("UPDATE tbl SET s = 'waiting éléphant'", dbname="latin1", commit=True)
+    time.sleep(2)
+    running = data.pg_get_activities()
+    assert "éléphant" in running[0].query
+    (waiting,) = data.pg_get_waiting()
+    assert "waiting éléphant" in waiting.query
+    (blocking,) = data.pg_get_blocking()
+    assert "blocking éléphant" in blocking.query
+
+    # Terminate blocking backend in order to avoid side effects in following tests (e.g.
+    # test_ui.txt).
+    data.pg_terminate_backend(blocking.pid)
+    for __ in range(10):
+        if not data.pg_get_waiting():
+            break
+        time.sleep(1)
+    else:
+        raise AssertionError("could not terminate blocking backend")


### PR DESCRIPTION
When the encoding of a database is not UTF8. Queries with special
caracters might crash pg_activity with the message :

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 26:
++  invalid continuation byte

This patch fixes the issue by querying pg_database.encoding and using it
to encode the string.