### PR TITLE
Add a waitevent column to blocking queries

### DIFF
--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "PG_ACTIVITY 1"
-.TH PG_ACTIVITY 1 "2021-05-17" "pg_activity 2.1.5" "Command line tool for PostgreSQL server activity monitoring."
+.TH PG_ACTIVITY 1 "2021-05-21" "pg_activity 2.1.5" "Command line tool for PostgreSQL server activity monitoring."
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -205,8 +205,8 @@ The running queries panel shows all running queries, transactions or backends
 .IX Item "- WRITE/s: write thruput as reported by the psutil library;"
 .IP "\- \fB\s-1TIME\s0\fR: time since the beginning of the query / transaction / backend start depending on the \fB\s-1DURATION_MODE\s0\fR currently in use;" 2
 .IX Item "- TIME: time since the beginning of the query / transaction / backend start depending on the DURATION_MODE currently in use;"
-.IP "\- \fBWaiting\fR: specific wait event if available. Otherwise, a boolean indicating that we are waiting for a Lock;" 2
-.IX Item "- Waiting: specific wait event if available. Otherwise, a boolean indicating that we are waiting for a Lock;"
+.IP "\- \fBWaiting\fR: for PostgreSQL 9.6+: a specific wait event or nothing. Otherwise, a boolean indicating if we are waiting for a Lock;" 2
+.IX Item "- Waiting: for PostgreSQL 9.6+: a specific wait event or nothing. Otherwise, a boolean indicating if we are waiting for a Lock;"
 .IP "\- \fB\s-1IOW\s0\fR: boolean indicating that the process is waiting for \s-1IO\s0 as reported by the psutil library;" 2
 .IX Item "- IOW: boolean indicating that the process is waiting for IO as reported by the psutil library;"
 .IP "\- \fBstate\fR: state of the backend;" 2
@@ -267,6 +267,8 @@ requiered by another session. It shows following information:
 .IX Item "- MODE: the mode of the lock;"
 .IP "\- \fB\s-1TIME+\s0\fR: the duration of the query, transaction or session depending on the \fB\s-1DURATION_MODE\s0\fR setting;" 2
 .IX Item "- TIME+: the duration of the query, transaction or session depending on the DURATION_MODE setting;"
+.IP "\- \fBWaiting\fR: for PostgreSQL 9.6+: a specific wait event or nothing. Otherwise, a boolean indicating if we are waiting for a Lock;" 2
+.IX Item "- Waiting: for PostgreSQL 9.6+: a specific wait event or nothing. Otherwise, a boolean indicating if we are waiting for a Lock;"
 .IP "\- \fBstate\fR: the state of the transaction;" 2
 .IX Item "- state: the state of the transaction;"
 .IP "\- \fBQuery\fR: the query." 2

--- a/docs/man/pg_activity.pod
+++ b/docs/man/pg_activity.pod
@@ -73,7 +73,7 @@ B<min duration> seconds. It displays the following information:
 
 =item - B<TIME>: time since the beginning of the query / transaction / backend start depending on the B<DURATION_MODE> currently in use;
 
-=item - B<Waiting>: specific wait event if available. Otherwise, a boolean indicating that we are waiting for a Lock;
+=item - B<Waiting>: for PostgreSQL 9.6+: a specific wait event or nothing. Otherwise, a boolean indicating if we are waiting for a Lock;
 
 =item - B<IOW>: boolean indicating that the process is waiting for IO as reported by the psutil library;
 
@@ -138,6 +138,8 @@ requiered by another session. It shows following information:
 =item - B<MODE>: the mode of the lock;
 
 =item - B<TIME+>: the duration of the query, transaction or session depending on the B<DURATION_MODE> setting;
+
+=item - B<Waiting>: for PostgreSQL 9.6+: a specific wait event or nothing. Otherwise, a boolean indicating if we are waiting for a Lock;
 
 =item - B<state>: the state of the transaction;
 

--- a/pgactivity/activities.py
+++ b/pgactivity/activities.py
@@ -8,7 +8,8 @@ import attr
 import psutil
 
 from .types import (
-    BWProcess,
+    BlockingProcess,
+    WaitingProcess,
     IOCounter,
     LoadAverage,
     LocalRunningProcess,
@@ -141,7 +142,7 @@ def ps_complete(
     return local_procs, io_read, io_write
 
 
-T = TypeVar("T", RunningProcess, BWProcess, LocalRunningProcess)
+T = TypeVar("T", RunningProcess, WaitingProcess, BlockingProcess, LocalRunningProcess)
 
 
 def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T]:

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -251,7 +251,7 @@ class Data:
             query = queries.get("get_pg_activity_post_90600")
         elif self.pg_num_version >= 90200:
             query = queries.get("get_pg_activity_post_90200")
-        elif self.pg_num_version < 90200:
+        else:
             query = queries.get("get_pg_activity")
 
         duration_column = self.get_duration_column(duration_mode)
@@ -269,7 +269,7 @@ class Data:
         """
         if self.pg_num_version >= 90200:
             query = queries.get("get_waiting_post_90200")
-        elif self.pg_num_version < 90200:
+        else:
             query = queries.get("get_waiting")
 
         duration_column = self.get_duration_column(duration_mode)

--- a/pgactivity/queries/get_blocking.sql
+++ b/pgactivity/queries/get_blocking.sql
@@ -18,7 +18,8 @@ SELECT
       CASE WHEN sq.query LIKE '<IDLE>%%'
           THEN NULL
           ELSE sq.query
-      END AS query
+      END AS query,
+      waiting AS wait
   FROM
       (
       SELECT
@@ -35,7 +36,8 @@ SELECT
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             NULL AS state,
-            blocking.relation::regclass AS relation
+            blocking.relation::regclass AS relation,
+            pg_stat_activity.waiting
         FROM
             pg_locks AS blocking
             JOIN (
@@ -67,7 +69,8 @@ SELECT
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             NULL AS state,
-            blocking.relation::regclass AS relation
+            blocking.relation::regclass AS relation,
+            pg_stat_activity.waiting
         FROM
             pg_locks AS blocking
             JOIN (
@@ -100,6 +103,7 @@ GROUP BY
       usename,
       client,
       state,
-      relation
+      relation,
+      wait
 ORDER BY
       duration DESC;

--- a/pgactivity/queries/get_blocking_post_90600.sql
+++ b/pgactivity/queries/get_blocking_post_90600.sql
@@ -1,4 +1,4 @@
--- Get blocking queries >= 9.2
+-- Get blocking queries >= 9.6
 SELECT
       pid,
       application_name,
@@ -11,7 +11,7 @@ SELECT
       duration,
       state,
       query,
-      waiting as wait
+      wait_event as wait
   FROM
       (
       SELECT
@@ -29,7 +29,7 @@ SELECT
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,
             blocking.relation::regclass AS relation,
-            pg_stat_activity.waiting
+            pg_stat_activity.wait_event
         FROM
             pg_locks AS blocking
             JOIN (
@@ -63,7 +63,7 @@ SELECT
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,
             blocking.relation::regclass AS relation,
-            pg_stat_activity.waiting
+            pg_stat_activity.wait_event
         FROM
             pg_locks AS blocking
             JOIN (

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -68,6 +68,8 @@ def test_blocking_waiting(postgresql, data, execute):
     (waiting,) = data.pg_get_waiting()
     assert "blocking" in blocking.query
     assert "waiting" in waiting.query
+    if postgresql.server_version >= 100000:
+        assert blocking.wait == "ClientRead"
 
 
 def test_cancel_backend(postgresql, data, execute):

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -120,7 +120,7 @@ MEM%              state   Query
 ...              flag=Flag.PID | Flag.DATABASE | Flag.APPNAME | Flag.RELATION | Flag.CLIENT | Flag.WAIT,
 ...              sort_key=SortKey.duration)
 >>> columns_header(term, ui, width=150)
-PID    DATABASE                      APP           CLIENT  RELATION              state   Query
+PID    DATABASE                      APP           CLIENT  RELATION          Waiting              state   Query
 
 >>> ui.evolve(query_mode=QueryMode.activities)
 >>> columns_header(term, ui, width=150)
@@ -261,7 +261,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
                                              * s.units) > 5000;
 
 >>> processes2 = [
-...     BWProcess(
+...     BlockingProcess(
 ...         pid="6239",
 ...         application_name="pgbench",
 ...         database="pgbench",
@@ -271,10 +271,11 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         type="transactionid",
 ...         relation="None",
 ...         duration=666,
+...         wait="Client Read",
 ...         state="active",
 ...         query="END;"
 ...     ),
-...     BWProcess(
+...     BlockingProcess(
 ...         pid="6228",
 ...         application_name="pgbench",
 ...         database="pgbench",
@@ -284,6 +285,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         type="tuple",
 ...         relation="ahah",
 ...         duration=0.000413,
+...         wait="Client Read",
 ...         state="idle in transaction",
 ...         query="UPDATE pgbench_branches SET bbalance = bbalance + 1788 WHERE bid = 68;",
 ...     ),
@@ -296,8 +298,8 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
                                              bid = 68;
 >>> ui = UI.make(query_mode=QueryMode.blocking, flag=allflags)
 >>> processes_rows(term, ui, SelectableProcesses(processes2), width=250)
-6239   pgbench                   pgbench         postgres          1.2.3.4      None    transactionid    ExclusiveLock  11:06.00             active   END;
-6228   pgbench                   pgbench         postgres            local      ahah            tuple RowExclusiveLock  0.000413      idle in trans   UPDATE pgbench_branches SET bbalance = bbalance + 1788 WHERE bid = 68;
+6239   pgbench                   pgbench         postgres          1.2.3.4      None    transactionid    ExclusiveLock  11:06.00      Client Read             active   END;
+6228   pgbench                   pgbench         postgres            local      ahah            tuple RowExclusiveLock  0.000413      Client Read      idle in trans   UPDATE pgbench_branches SET bbalance = bbalance + 1788 WHERE bid = 68;
 
 >>> processes1b = [
 ...     RunningProcess(


### PR DESCRIPTION
Blocking queries can be long for a number of reasons, the wait_event
column of pg_activity can help us understand them. Therefore, it was
added to the blocking query panel.