### PR TITLE
Overhaul the header view

### DIFF
--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -105,7 +105,7 @@ No activity, first screen followed by help screen:
 
 >>> run_ui(options, ["h", "z", "q"])  # doctest: +ELLIPSIS
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT              state   Query
 <BLANKLINE>
@@ -150,7 +150,7 @@ Mode
 Press any key to exit.
 ------------------------------------------------------------------------------------------- sending key 'z' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT              state   Query
 <BLANKLINE>
@@ -193,7 +193,7 @@ change query mode then quit:
 >>> assert len(keys) == len(expected_timeouts)
 >>> run_ui(options, keys, expected_timeouts=expected_timeouts)  # doctest: +ELLIPSIS
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -219,7 +219,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key '-' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -245,7 +245,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key '-' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 0.5s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -271,7 +271,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key '+' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -297,7 +297,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key ' ' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -323,7 +323,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key 'T' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -349,7 +349,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key '3' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -375,7 +375,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key 'r' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -401,7 +401,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key ' ' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -427,7 +427,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key 'T' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -453,7 +453,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key 'c' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -479,7 +479,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key '2' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: transaction
                                 WAITING QUERIES
 DATABASE                     USER           CLIENT  RELATION             TYPE             MODE              state   Query
 <BLANKLINE>
@@ -505,7 +505,7 @@ DATABASE                     USER           CLIENT  RELATION             TYPE   
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key '1' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT              state   Query
 tests                    postgres     127.0.0.1/32      idle in trans   SELECT pg_sleep(0)
@@ -531,7 +531,7 @@ tests                    postgres     127.0.0.1/32      idle in trans   SELECT p
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key '3' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode: transaction
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: transaction
                                 BLOCKING QUERIES
 DATABASE                     USER           CLIENT  RELATION             TYPE             MODE              state   Query
 <BLANKLINE>
@@ -699,7 +699,7 @@ independent of the number of digits in PIDs.)
 ... ):
 ...     run_ui(options, keys, render_footer=True, width=140)  # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 42
@@ -725,7 +725,7 @@ PID    DATABASE                      state   Query
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ---------------------------------------------------------- sending key 'KEY_DOWN' ----------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 42
@@ -751,7 +751,7 @@ PID    DATABASE                      state   Query
 C Cancel current query     K Terminate current query  Space Tag/untag current qu Other Back to activities   q Quit                          
 ------------------------------------------------------------- sending key '2' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 WAITING QUERIES
 PID    DATABASE          RELATION             TYPE             MODE              state   Query
 ...    tests                 None    transactionid        ShareLock             active   UPDATE t SET s = 'waiting'
@@ -777,7 +777,7 @@ PID    DATABASE          RELATION             TYPE             MODE             
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ------------------------------------------------------------- sending key '3' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 BLOCKING QUERIES
 PID    DATABASE          RELATION             TYPE             MODE              state   Query
 ...    tests                 None    transactionid    ExclusiveLock      idle in trans   UPDATE t SET s = 'blocking'
@@ -803,7 +803,7 @@ PID    DATABASE          RELATION             TYPE             MODE             
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ------------------------------------------------------------- sending key '1' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 42
@@ -829,7 +829,7 @@ PID    DATABASE                      state   Query
 F1/1 Running queries   F2/2 Waiting queries   F3/3 Blocking queries  Space Pause/unpause    q Quit                 h Help                   
 ---------------------------------------------------------- sending key 'KEY_DOWN' ----------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 42
@@ -859,7 +859,7 @@ C Cancel current query     K Terminate current query  Space Tag/untag current qu
 <BLANKLINE>
 ------------------------------------------------------------- sending key 'n' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 42
@@ -889,7 +889,7 @@ C Cancel current query     K Terminate current query  Space Tag/untag current qu
 <BLANKLINE>
 ------------------------------------------------------------- sending key 'y' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 43
@@ -915,7 +915,7 @@ PID    DATABASE                      state   Query
                              Process ... terminated
 ---------------------------------------------------------- sending key 'KEY_DOWN' ----------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 43
@@ -941,7 +941,7 @@ PID    DATABASE                      state   Query
                              Process ... terminated
 ------------------------------------------------------------- sending key ' ' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 43
@@ -967,7 +967,7 @@ PID    DATABASE                      state   Query
 C Cancel current query     K Terminate current query  Space Tag/untag current qu Other Back to activities   q Quit                          
 ------------------------------------------------------------- sending key 'j' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 43
@@ -993,7 +993,7 @@ PID    DATABASE                      state   Query
 C Cancel current query     K Terminate current query  Space Tag/untag current qu Other Back to activities   q Quit                          
 ------------------------------------------------------------- sending key ' ' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               2      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 ...    tests                 idle in trans   SELECT 43
@@ -1023,7 +1023,7 @@ C Cancel current query     K Terminate current query  Space Tag/untag current qu
 <BLANKLINE>
 ------------------------------------------------------------- sending key 'y' --------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
- Size:       106.07M - 0B/s           | TPS:               0      | Active connections:               1      | Duration mode:       query
+ Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 1 ⋅ Duration mode: query
                                 RUNNING QUERIES
 PID    DATABASE                      state   Query
 <BLANKLINE>

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -69,10 +69,10 @@ Remote host:
 >>> header(term, ui, host=host, dbinfo=dbinfo, pg_version="PostgreSQL 9.6", tps=12, active_connections=0,
 ...        width=200)
 PostgreSQL 9.6 - server - pgadm@server.prod.tld:5433/app - Ref.: 10s
- Size:         9.06P - 9.76K/s        | TPS:              12      | Active connections:               0      | Duration mode:     backend
+ Size: 9.06P - 9.76K/s ⋅ TPS: 12 ⋅ Active connections: 0 ⋅ Duration mode: backend
 >>> header(term, ui, host=host, dbinfo=dbinfo, pg_version="PostgreSQL 9.6", tps=12, active_connections=0)
 PostgreSQL 9.6 - server - pgadm@server.prod.tld:5433/app - Ref.: 10s
- Size:         9.06P - 9.76K/s        | TPS:              12      | Active
+ Size: 9.06P - 9.76K/s ⋅ TPS: 12 ⋅ Active connections: 0 ⋅ Duration mode:
 
 Local host, with priviledged access:
 
@@ -89,10 +89,10 @@ Local host, with priviledged access:
 >>> header(term, ui, host=host, dbinfo=dbinfo, pg_version="PostgreSQL 13.1", tps=1, active_connections=79,
 ...        system_info=sysinfo, width=150)
 PostgreSQL 13.1 - localhost - tester@host:5432/postgres - Ref.: 2s - Min. duration: 1.2s
- Size:       117.74M - 12B/s          | TPS:               1      | Active connections:              79      | Duration mode:       query
- Mem.:      42.5% - 1.87G/5.75G       | IO Max:       12/s
- Swap:       0.0% - 2.29K/5.88G       | Read:          128B/s - 6/s
- Load:        25.00 0.19 0.39         | Write:          8B/s - 9/s
+ Size: 117.74M - 12B/s ⋅ TPS: 1 ⋅ Active connections: 79 ⋅ Duration mode: query
+ Mem.: 42.5% - 1.87G/5.75G,   IO Max: 12/s
+ Swap: 0.0% - 2.29K/5.88G,    Read:   128B/s - 6/s
+ Load: 25.00 0.19 0.39,       Write:  8B/s - 9/s
 
 
 Tests for columns_header()
@@ -395,10 +395,10 @@ Tests for screen()
 ...     width=150,
 ... )
 PostgreSQL 13 - testhost - pgadm@server.prod.tld:5433/app - Ref.: 10s - Min. duration: 1s
- Size:         9.06P - 9.76K/s        | TPS:               5      | Active connections:               7      | Duration mode:     backend
- Mem.:      2.5% - 954.85M/3.93G      | IO Max:       76/s
- Swap:       1.0% - 2.29K/5.88G       | Read:          128B/s - 6/s
- Load:         0.50 1.90 0.93         | Write:          8B/s - 9/s
+ Size: 9.06P - 9.76K/s ⋅ TPS: 5 ⋅ Active connections: 7 ⋅ Duration mode: backend
+ Mem.: 2.5% - 954.85M/3.93G,   IO Max: 76/s
+ Swap: 1.0% - 2.29K/5.88G,     Read:   128B/s - 6/s
+ Load: 0.50 1.90 0.93,         Write:  8B/s - 9/s
                                 RUNNING QUERIES
 PID    DATABASE           CPU% MEM%              state   Query
 1234   business            2.4  1.0             active   SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date >
@@ -433,10 +433,10 @@ F1/1 Running queries    F2/2 Waiting queries    F3/3 Blocking queries   Space Pa
 ...     message=f"Process {processes3[-1].pid} killed",
 ... )
 PostgreSQL 13 - testhost - pgadm@server.prod.tld:5433/app - Ref.: 10s - Min.
- Size:         9.06P - 9.76K/s        | TPS:               5      | Active
- Mem.:      2.5% - 954.85M/3.93G      | IO Max:       76/s
- Swap:       1.0% - 2.29K/5.88G       | Read:          128B/s - 6/s
- Load:         0.50 1.90 0.93         | Write:          8B/s - 9/s
+ Size: 9.06P - 9.76K/s ⋅ TPS: 5 ⋅ Active connections: 7 ⋅ Duration mode: backend
+ Mem.: 2.5% - 954.85M/3.93G,   IO Max: 76/s
+ Swap: 1.0% - 2.29K/5.88G,     Read:   128B/s - 6/s
+ Load: 0.50 1.90 0.93,         Write:  8B/s - 9/s
                                 RUNNING QUERIES
 PID    DATABASE           CPU% MEM%              state   Query
 1234   business            2.4  1.0             active   SELECT product_id, p.na


### PR DESCRIPTION
We rework the header view in order to make the rendering more compact,
by limiting the amount of white spaces between columns, and to make the
columns / rows data more extensible.

Now the header() view displays two blocks:

* first row (containing "Size", "Active connections", "Duration mode"
  information) is always visible and has its own alignment
* subsequent rows, only available in local mode and displaying extra
  system information, also use their own alignment

In the first block, we change the | column delimiter into a blue ⋅. In
the second one, we use a comma (similarly to what top uses).

Besides, columns no longer have a fixed width, thus make the rendering
more compact.

Adding extra columns should be simpler now, thus preparing work for #213.