### PR TITLE
Blocking query now lists transactions which blocks virtualxid.

### DIFF
--- a/pgactivity/queries/get_blocking_post_90200.sql
+++ b/pgactivity/queries/get_blocking_post_90200.sql
@@ -21,7 +21,7 @@ SELECT
             blocking.mode,
             pg_stat_activity.datname,
             pg_stat_activity.usename,
-	    CASE WHEN pg_stat_activity.client_addr IS NULL
+            CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
                 ELSE pg_stat_activity.client_addr::TEXT
             END AS client,
@@ -39,7 +39,41 @@ SELECT
                       pg_locks
                  WHERE
                       NOT granted
-	    ) AS blocked ON (blocking.transactionid = blocked.transactionid)
+            ) AS blocked ON (blocking.transactionid = blocked.transactionid)
+            JOIN pg_stat_activity ON (blocking.pid = pg_stat_activity.pid)
+       WHERE
+            blocking.granted
+        AND CASE WHEN %(min_duration)s = 0
+                THEN true
+                ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
+            END
+      UNION ALL
+      SELECT
+            blocking.pid,
+            pg_stat_activity.application_name,
+            pg_stat_activity.query,
+            blocking.mode,
+            pg_stat_activity.datname,
+            pg_stat_activity.usename,
+            CASE WHEN pg_stat_activity.client_addr IS NULL
+                THEN 'local'
+                ELSE pg_stat_activity.client_addr::TEXT
+            END AS client,
+            blocking.locktype,
+            EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
+            pg_stat_activity.state as state,
+            blocking.relation::regclass AS relation,
+            pg_stat_activity.waiting
+        FROM
+            pg_locks AS blocking
+            JOIN (
+                SELECT
+                      virtualxid
+                  FROM
+                      pg_locks
+                 WHERE
+                      NOT granted
+            ) AS blocked ON (blocking.virtualxid = blocked.virtualxid)
             JOIN pg_stat_activity ON (blocking.pid = pg_stat_activity.pid)
        WHERE
             blocking.granted

--- a/pgactivity/queries/get_blocking_post_90600.sql
+++ b/pgactivity/queries/get_blocking_post_90600.sql
@@ -21,7 +21,7 @@ SELECT
             blocking.mode,
             pg_stat_activity.datname,
             pg_stat_activity.usename,
-	    CASE WHEN pg_stat_activity.client_addr IS NULL
+            CASE WHEN pg_stat_activity.client_addr IS NULL
                 THEN 'local'
                 ELSE pg_stat_activity.client_addr::TEXT
             END AS client,
@@ -39,7 +39,41 @@ SELECT
                       pg_locks
                  WHERE
                       NOT granted
-	    ) AS blocked ON (blocking.transactionid = blocked.transactionid)
+            ) AS blocked ON (blocking.transactionid = blocked.transactionid)
+            JOIN pg_stat_activity ON (blocking.pid = pg_stat_activity.pid)
+       WHERE
+            blocking.granted
+        AND CASE WHEN %(min_duration)s = 0
+                THEN true
+                ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
+            END
+      UNION ALL
+      SELECT
+            blocking.pid,
+            pg_stat_activity.application_name,
+            pg_stat_activity.query,
+            blocking.mode,
+            pg_stat_activity.datname,
+            pg_stat_activity.usename,
+            CASE WHEN pg_stat_activity.client_addr IS NULL
+                THEN 'local'
+                ELSE pg_stat_activity.client_addr::TEXT
+            END AS client,
+            blocking.locktype,
+            EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
+            pg_stat_activity.state as state,
+            blocking.relation::regclass AS relation,
+            pg_stat_activity.wait_event
+        FROM
+            pg_locks AS blocking
+            JOIN (
+                SELECT
+                      virtualxid
+                  FROM
+                      pg_locks
+                 WHERE
+                      NOT granted
+            ) AS blocked ON (blocking.virtualxid = blocked.virtualxid)
             JOIN pg_stat_activity ON (blocking.pid = pg_stat_activity.pid)
        WHERE
             blocking.granted


### PR DESCRIPTION
I had a long running transaction which blocked a repack process. I realized that pg_activity couldn't display which ended up with this patch. 

I could only test get_blocking_post_90600.sql since I don't have any old environment.