### PR TITLE
add autocommit option to the execute function of the tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,10 @@ def execute(postgresql):
 
     loop = asyncio.new_event_loop()
 
-    def execute(query: str, commit: bool = False) -> None:
+    def execute(query: str, commit: bool = False, autocommit: bool = False) -> None:
         def _execute() -> None:
             conn = psycopg2.connect(**postgresql.info.dsn_parameters)
+            conn.autocommit = autocommit
             cnx.append(conn)
             with conn.cursor() as c:
                 try:
@@ -33,7 +34,7 @@ def execute(postgresql):
                     psycopg2.errors.QueryCanceledError,
                 ):
                     return
-                if commit:
+                if not autocommit and commit:
                     conn.commit()
 
         loop.call_soon_threadsafe(_execute)


### PR DESCRIPTION
Some tests require to run queries outside of a transaction block.
eg: CREATE INDEX CONCURRENTLY

This is necessary to add tests to #224.