### PR TITLE
use threads for queries launched in //

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
-import asyncio
 import pathlib
-import threading
-from typing import Optional
+import time
+from threading import Thread
+from typing import Dict, List, Optional
 
 import psycopg2
 import psycopg2.errors
+from psycopg2.extensions import (
+    TRANSACTION_STATUS_ACTIVE,
+    TRANSACTION_STATUS_INTRANS,
+    TRANSACTION_STATUS_INERROR,
+)
 import pytest
 
 
@@ -13,52 +18,181 @@ def datadir() -> pathlib.Path:
     return pathlib.Path(__file__).parent / "data"
 
 
-@pytest.fixture
-def execute(postgresql):
-    """Create a thread and return an execute() function that will run SQL queries in that
-    thread.
-    """
-    cnx = []
-
-    loop = asyncio.new_event_loop()
-
-    def execute(
+class PgThread(Thread):
+    def __init__(
+        self: "PgThread",
+        connection_string: Dict[str, str],
         query: str,
-        commit: bool = False,
+        idle_in_transaction: bool = False,
         autocommit: bool = False,
-        dbname: Optional[str] = None,
     ) -> None:
-        def _execute() -> None:
-            connection_parms = postgresql.info.dsn_parameters
-            if dbname:
-                connection_parms["dbname"] = dbname
-            conn = psycopg2.connect(**connection_parms)
-            conn.autocommit = autocommit
-            cnx.append(conn)
+        """Creates a thread to execute a query
+
+        :param Optional[str] database: the database to connect to if different from the one provided during the creation of the class
+        :param str query: query to execute
+        :param bool idle_in_transaction: should the transaction remain idle_in_transaction, default False
+        :param bool autocommit: should we activate autocommit, default False (usefull for some non transactionnal DDL)
+        """
+        Thread.__init__(self)
+        self.connection_string: Dict[str, str] = connection_string
+        self.query: str = query
+        self.idle_in_transaction: bool = idle_in_transaction
+        self.autocommit: bool = autocommit
+        self.conn: Optional[psycopg2.connection] = None
+
+    def run(self: "PgThread") -> None:
+        """Execute a query"""
+        self.conn = psycopg2.connect(**self.connection_string)
+        self.conn.autocommit = self.autocommit
+        try:
+            with self.conn.cursor() as c:
+                c.execute(self.query)
+                while self.idle_in_transaction:
+                    time.sleep(0.1)
+            self.conn.commit()
+        except (
+            psycopg2.errors.AdminShutdown,
+            psycopg2.errors.QueryCanceledError,
+        ):
+            pass
+        self.conn.close()
+
+    def stop_idle_in_transactioning(self: "PgThread") -> None:
+        """Remove the idle_in_transaction flag so that we stop waiting"""
+        self.idle_in_transaction = False
+
+    def is_idle_in_transaction(self: "PgThread") -> bool:
+        """Check if the transaction is ile in transaction
+
+        :rtype: bool
+        """
+        # This syntaxe is used for mypy otherwise it complains that the value returned could be any
+        return (
+            True
+            if self.conn is not None
+            and self.conn.info.transaction_status
+            in [TRANSACTION_STATUS_INTRANS, TRANSACTION_STATUS_INERROR]
+            else False
+        )
+
+    def is_active(self: "PgThread") -> bool:
+        """Check if the transaction is active (a command is running)
+
+        :rtype: bool
+        :raises Exception: if we are not connected
+        """
+        # This syntaxe is used for mypy otherwise it complains that the value returned could be any
+        return (
+            True
+            if (
+                self.conn is not None
+                and self.conn.info.transaction_status == TRANSACTION_STATUS_ACTIVE
+            )
+            else False
+        )
+
+    def is_query_locked(self: "PgThread") -> bool:
+        """Check if this session is waiting because of a lock
+
+        :rtype: bool
+        :raises Exception: if we are not connected
+        """
+        if self.conn is not None and not self.conn.closed:
+            pid = self.conn.info.backend_pid
+            conn = psycopg2.connect(**self.connection_string)
             with conn.cursor() as c:
-                try:
-                    c.execute(query)
-                except (
-                    psycopg2.errors.AdminShutdown,
-                    psycopg2.errors.QueryCanceledError,
+                # Look for a lock that is not granted for our pid
+                c.execute(
+                    f"SELECT * FROM pg_locks l WHERE l.pid = {pid} AND NOT l.granted"
+                )
+                if c.rowcount >= 1:
+                    conn.close
+                    return True
+                else:
+                    conn.close
+        return False
+
+
+class PgThreadCoord:
+    def __init__(self: "PgThreadCoord", connection_string: Dict[str, str]) -> None:
+        """Create a thread coordinator to execute queries on an instance
+
+        :param Dict[str, str] connection_string connection string as presented in psycopg2.connection.info.dsn_parameters
+        """
+        self.idle_in_transaction_threads: List[PgThread] = []
+        self.others_threads: List[PgThread] = []
+        self.connection_string: Dict[str, str] = connection_string
+
+    def execute_thread(
+        self: "PgThreadCoord",
+        query: str,
+        database: Optional[str] = None,
+        idle_in_transaction: bool = False,
+        autocommit: bool = False,
+        wait_completion: bool = False,
+        wait_locked: bool = False,
+    ) -> None:
+        """execute a query in a thread
+
+        :param str query: query to execute
+        :param Optional[str] database: the database to connect to if different from the one provided during the creation of the class
+        :param bool idle_in_transaction: should the transaction remain idle_in_transaction, default False
+        :param bool autocommit: should we activate autocommit, default False (usefull for some non transactionnal DDL)
+        :param bool wait_completion: wait for the query to finish before continuing the flow of the program
+                                     this is usefull quick queries to do the setup of the tests
+        :param bool wait_locked: wait for the query to wait for a lock before continuing the flow of the program
+                                 this is usefull to check the blocking / waiting queries
+        :raises AssertionError: if we wait for more than 2 seconds before the transaction becomes idle in transaction
+        :raises AssertionError: if we wait for more than 2 seconds before the transaction becomes active or locked
+        """
+        cstr = self.connection_string
+        if database is not None:
+            cstr["dbname"] = database
+
+        t = PgThread(cstr, query, idle_in_transaction, autocommit)
+        t.start()
+        if wait_completion:
+            # Sometimes we just want too execute a query
+            # Threads are useless here but it's quicker to write
+            t.join()
+        else:
+            if idle_in_transaction:
+                # We put queries in idle in transaction state to induce locks
+                # We have to wait for the status to be correct
+                loopcnt = 0
+                while not t.is_idle_in_transaction():
+                    time.sleep(0.1)
+                    loopcnt += 1
+                    if loopcnt > 20:
+                        raise AssertionError(
+                            "Timed out before transaction became idle in transaction"
+                        )
+                self.idle_in_transaction_threads.append(t)
+            else:
+                # We at least want to have the query running
+                # Sometimes it's not nough and we want the query to be locked
+                # The query could also be so short we didn't see it as active
+                # It doesn't matter, we will timeout in that case.
+                loopcnt = 0
+                while (not wait_locked and not t.is_active()) or (
+                    wait_locked and not t.is_query_locked()
                 ):
-                    return
-                if not autocommit and commit:
-                    conn.commit()
+                    time.sleep(0.1)
+                    loopcnt += 1
+                    if loopcnt > 20:
+                        raise AssertionError(
+                            "Timed out, the transaction is not active or locked"
+                        )
+                self.others_threads.append(t)
 
-        loop.call_soon_threadsafe(_execute)
+    def cleanup(self: "PgThreadCoord") -> None:
+        """wait for all thread to be stopped"""
+        # thread idle in transation need to we released before finishing
+        for t in self.idle_in_transaction_threads:
+            t.stop_idle_in_transactioning()
+            t.join()
 
-    def run_loop() -> None:
-        asyncio.set_event_loop(loop)
-        loop.run_forever()
-
-    thread = threading.Thread(target=run_loop, daemon=True)
-    thread.start()
-
-    yield execute
-
-    for conn in cnx:
-        loop.call_soon_threadsafe(conn.close)
-    loop.call_soon_threadsafe(loop.stop)
-
-    thread.join(timeout=2)
+        # other thread shoud be released because there is no more idle in transaction
+        # threads and finish gracefully
+        for t in self.others_threads:
+            t.join()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,9 +190,9 @@ class PgThreadCoord:
         # thread idle in transation need to we released before finishing
         for t in self.idle_in_transaction_threads:
             t.stop_idle_in_transactioning()
-            t.join()
+            t.join(timeout=2)
 
         # other thread shoud be released because there is no more idle in transaction
         # threads and finish gracefully
         for t in self.others_threads:
-            t.join()
+            t.join(timeout=2)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -162,7 +162,9 @@ def test_encoding(postgresql, data):
         (waiting,) = data.pg_get_waiting()
         (blocking,) = data.pg_get_blocking()
 
-        assert "éléphant" in running[0].query  # could be any éléphant first with threads
+        assert (
+            "éléphant" in running[0].query
+        )  # could be any éléphant first with threads
         assert "waiting éléphant" in waiting.query
         assert "blocking éléphant" in blocking.query
     finally:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -51,48 +51,52 @@ def test_activities(postgresql, data):
 
 def test_blocking_waiting(postgresql, data):
     tc = PgThreadCoord(postgresql.info.dsn_parameters)
-    with postgresql.cursor() as cur:
-        cur.execute("CREATE TABLE t (s text)")
-        cur.execute("INSERT INTO t VALUES ('init')")
-    postgresql.commit()
+    try:
+        with postgresql.cursor() as cur:
+            cur.execute("CREATE TABLE t (s text)")
+            cur.execute("INSERT INTO t VALUES ('init')")
+        postgresql.commit()
 
-    tc.execute_thread("UPDATE t SET s = 'blocking'", idle_in_transaction=True)
-    tc.execute_thread("UPDATE t SET s = 'waiting 1'", wait_locked=True)
-    tc.execute_thread("UPDATE t SET s = 'waiting 2'", wait_locked=True)
+        tc.execute_thread("UPDATE t SET s = 'blocking'", idle_in_transaction=True)
+        tc.execute_thread("UPDATE t SET s = 'waiting 1'", wait_locked=True)
+        tc.execute_thread("UPDATE t SET s = 'waiting 2'", wait_locked=True)
 
-    blocking = data.pg_get_blocking()
-    waiting = data.pg_get_waiting()
+        blocking = data.pg_get_blocking()
+        waiting = data.pg_get_waiting()
 
-    assert len(blocking) == 2
-    assert len(waiting) == 2
-    assert "blocking" in blocking[0].query
-    assert "waiting" in waiting[0].query
-    assert "waiting" in waiting[1].query
-    if postgresql.server_version >= 100000:
-        assert blocking[0].wait == "ClientRead"
-    assert str(blocking[0].type) == "transactionid"
-    tc.cleanup()
+        assert len(blocking) == 2
+        assert len(waiting) == 2
+        assert "blocking" in blocking[0].query
+        assert "waiting" in waiting[0].query
+        assert "waiting" in waiting[1].query
+        if postgresql.server_version >= 100000:
+            assert blocking[0].wait == "ClientRead"
+        assert str(blocking[0].type) == "transactionid"
+    finally:
+        tc.cleanup()
 
 
 def test_pg_get_blocking_virtualxid(postgresql, data):
     tc = PgThreadCoord(postgresql.info.dsn_parameters)
-    with postgresql.cursor() as cur:
-        cur.execute("CREATE TABLE t(s text)")
-        cur.execute("INSERT INTO t VALUES ('init')")
-    postgresql.commit()
+    try:
+        with postgresql.cursor() as cur:
+            cur.execute("CREATE TABLE t(s text)")
+            cur.execute("INSERT INTO t VALUES ('init')")
+        postgresql.commit()
 
-    tc.execute_thread("UPDATE t SET s = 'blocking'", idle_in_transaction=True)
-    tc.execute_thread(
-        "CREATE INDEX CONCURRENTLY ON t(s)", autocommit=True, wait_locked=True
-    )
+        tc.execute_thread("UPDATE t SET s = 'blocking'", idle_in_transaction=True)
+        tc.execute_thread(
+            "CREATE INDEX CONCURRENTLY ON t(s)", autocommit=True, wait_locked=True
+        )
 
-    (blocking,) = data.pg_get_blocking()
-    (waiting,) = data.pg_get_waiting()
+        (blocking,) = data.pg_get_blocking()
+        (waiting,) = data.pg_get_waiting()
 
-    assert "blocking" in blocking.query
-    assert "CREATE INDEX CONCURRENTLY ON t(s)" in waiting.query
-    assert str(blocking.type) == "virtualxid"
-    tc.cleanup()
+        assert "blocking" in blocking.query
+        assert "CREATE INDEX CONCURRENTLY ON t(s)" in waiting.query
+        assert str(blocking.type) == "virtualxid"
+    finally:
+        tc.cleanup()
 
 
 def test_cancel_backend(postgresql, data):
@@ -112,50 +116,54 @@ def test_terminate_backend(postgresql, data):
 
 def test_pg_get_active_connections(data, postgresql):
     tc = PgThreadCoord(postgresql.info.dsn_parameters)
-    assert data.pg_get_active_connections() == 1
-    tc.execute_thread("select pg_sleep(2)")
-    assert data.pg_get_active_connections() == 2
-    tc.cleanup()
+    try:
+        assert data.pg_get_active_connections() == 1
+        tc.execute_thread("select pg_sleep(2)")
+        assert data.pg_get_active_connections() == 2
+    finally:
+        tc.cleanup()
 
 
 def test_encoding(postgresql, data):
     """Test for issue #149"""
     tc = PgThreadCoord(postgresql.info.dsn_parameters)
-    postgresql.set_session(autocommit=True)
-    with postgresql.cursor() as cur:
-        # plateform specific locales (,Centos, Ubuntu)
-        for encoding in ["fr_FR.latin1", "fr_FR.88591", "fr_FR.8859-1"]:
-            try:
-                cur.execute(
-                    f"CREATE DATABASE latin1 ENCODING 'latin1' TEMPLATE template0 LC_COLLATE '{encoding}' LC_CTYPE '{encoding}'"
-                )
-            except WrongObjectType:
-                continue
-            else:
-                break
+    try:
+        postgresql.set_session(autocommit=True)
+        with postgresql.cursor() as cur:
+            # plateform specific locales (,Centos, Ubuntu)
+            for encoding in ["fr_FR.latin1", "fr_FR.88591", "fr_FR.8859-1"]:
+                try:
+                    cur.execute(
+                        f"CREATE DATABASE latin1 ENCODING 'latin1' TEMPLATE template0 LC_COLLATE '{encoding}' LC_CTYPE '{encoding}'"
+                    )
+                except WrongObjectType:
+                    continue
+                else:
+                    break
 
-    tc.execute_thread(
-        "CREATE TABLE tbl(s text)", database="latin1", wait_completion=True
-    )
-    tc.execute_thread(
-        "INSERT INTO tbl(s) VALUES ('initilialized éléphant')",
-        database="latin1",
-        wait_completion=True,
-    )
-    tc.execute_thread(
-        "UPDATE tbl SET s = 'blocking éléphant'",
-        database="latin1",
-        idle_in_transaction=True,
-    )
-    tc.execute_thread(
-        "UPDATE tbl SET s = 'waiting éléphant'", database="latin1", wait_locked=True
-    )
+        tc.execute_thread(
+            "CREATE TABLE tbl(s text)", database="latin1", wait_completion=True
+        )
+        tc.execute_thread(
+            "INSERT INTO tbl(s) VALUES ('initilialized éléphant')",
+            database="latin1",
+            wait_completion=True,
+        )
+        tc.execute_thread(
+            "UPDATE tbl SET s = 'blocking éléphant'",
+            database="latin1",
+            idle_in_transaction=True,
+        )
+        tc.execute_thread(
+            "UPDATE tbl SET s = 'waiting éléphant'", database="latin1", wait_locked=True
+        )
 
-    running = data.pg_get_activities()
-    (waiting,) = data.pg_get_waiting()
-    (blocking,) = data.pg_get_blocking()
+        running = data.pg_get_activities()
+        (waiting,) = data.pg_get_waiting()
+        (blocking,) = data.pg_get_blocking()
 
-    assert "éléphant" in running[0].query  # could be any éléphant first with threads
-    assert "waiting éléphant" in waiting.query
-    assert "blocking éléphant" in blocking.query
-    tc.cleanup()
+        assert "éléphant" in running[0].query  # could be any éléphant first with threads
+        assert "waiting éléphant" in waiting.query
+        assert "blocking éléphant" in blocking.query
+    finally:
+        tc.cleanup()

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -5,6 +5,7 @@ Functional tests for 'ui' module
 >>> import optparse
 >>> import time
 >>> from unittest.mock import patch
+>>> from conftest import PgThreadCoord
 
 >>> import blessed
 >>> from blessed.keyboard import Keystroke
@@ -669,12 +670,11 @@ tests                 idle in trans   CREATE TABLE persons (firstname text, last
 
 Interactive mode:
 
->>> execute = getfixture("execute")
->>> execute("SELECT 42")
->>> execute("SELECT 43")
->>> execute("UPDATE t SET s = 'blocking'")
->>> execute("UPDATE t SET s = 'waiting'", commit=True)
->>> time.sleep(1)
+>>> tc = PgThreadCoord(postgres.info.dsn_parameters)
+>>> tc.execute_thread("SELECT 42", idle_in_transaction=True)
+>>> tc.execute_thread("SELECT 43", idle_in_transaction=True)
+>>> tc.execute_thread("UPDATE t SET s = 'blocking'", idle_in_transaction=True)
+>>> tc.execute_thread("UPDATE t SET s = 'waiting'", wait_locked=True)
 
 >>> options = optparse.Values(
 ...     defaults=dict(
@@ -1054,3 +1054,4 @@ Waiting query should be unblocked:
 ...     c.execute("SELECT s from t")
 ...     c.fetchall()
 [('waiting',)]
+>>> tc.cleanup()


### PR DESCRIPTION
* this enables us to do the following without locking ourselves
   * run blocking
   * run blocked
   * run blocked
* the wait_for_data is useless now because we wait until we are
  we are locked or idle_in_transaction before resuming the execution
* there is a cleanup at the end of the tests to avoid edge effects
* adds a test with multiple blockers
* changes the default for min_duration 1 => 0
* updates test_data and test_ui to use the new API