### PR TITLE
Cache shorten()

### DIFF
--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -57,6 +57,7 @@ class line_counter:
         return current_value
 
 
+@functools.lru_cache(maxsize=512)
 def shorten(term: Terminal, text: str, width: Optional[int] = None) -> str:
     r"""Truncate 'text' to fit in the given 'width' (or term.width).
 


### PR DESCRIPTION
Calls to shorten() appear to be a major bottleneck in the rendering
logic of the processes table. Especially this is called many times when
scrolling through the process list. We add a LRU cache to speed things
up.

See #249 and #239 for the rationale.