### PR TITLE
Fix IOW status

### DIFF
--- a/pgactivity/activities.py
+++ b/pgactivity/activities.py
@@ -52,7 +52,7 @@ def sys_get_proc(pid: int) -> Optional[SystemProcess]:
         cpu_times=cpu_times,
         read_delta=0,
         write_delta=0,
-        io_wait=status_iow == "disk sleep",
+        io_wait=(status_iow == psutil.STATUS_DISK_SLEEP),
         psutil_proc=psproc,
     )
 


### PR DESCRIPTION
The `disk sleep` had been used which seems to have a typo (` ` instead of `-`).
Safer to use a constant from psutil.