### PR TITLE
Add missing colum qualifier for dbname

### DIFF
--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -27,7 +27,7 @@ SELECT
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
   AND CASE WHEN %(dbname_filter)s IS NULL THEN true
-      ELSE datname ~* %(dbname_filter)s
+      ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/queries/get_pg_activity_post_90200.sql
+++ b/pgactivity/queries/get_pg_activity_post_90200.sql
@@ -24,7 +24,7 @@ SELECT
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
   AND CASE WHEN %(dbname_filter)s IS NULL THEN true
-      ELSE datname ~* %(dbname_filter)s
+      ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/queries/get_pg_activity_post_90600.sql
+++ b/pgactivity/queries/get_pg_activity_post_90600.sql
@@ -25,7 +25,7 @@ SELECT
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
   AND CASE WHEN %(dbname_filter)s IS NULL THEN true
-      ELSE datname ~* %(dbname_filter)s
+      ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;


### PR DESCRIPTION
This prevents an ambiguous column identifier error.