### PR TITLE
Do not display (nor wrap) the query when the column is not visible

### DIFF
--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -357,7 +357,7 @@ def processes_rows(
         indent = get_indent(ui) + " "
         qwidth = width - len(indent)
 
-        if process.query is not None:
+        if qwidth > 0 and process.query is not None:
             query = format_query(process.query, process.is_parallel_worker)
 
             if not ui.wrap_query:


### PR DESCRIPTION
This fixes up commit d8d54b2c8301afb39e39282642a8259d97e20abd which made
the UI crash when there was no horizontal space to display the query
column on the processes table. Now we don't display that column if it's
outside screen.