### PR TITLE
Keep focused line on top of processes table when query is wrapped

### DIFF
--- a/tests/test_scroll.txt
+++ b/tests/test_scroll.txt
@@ -43,6 +43,7 @@ Tests scrolling in processes_rows()
 7      pgbench                     active SELECT 7
 8      pgbench                     active SELECT 8
 9      pgbench                     active SELECT 9
+0      pgbench                     active SELECT 0
 >>> _ = sproc.focus_next()
 >>> sproc.position()
 0
@@ -67,6 +68,7 @@ For 5 display lines, the focus will be on the 4th .
 7      pgbench                     active SELECT 7
 8      pgbench                     active SELECT 8
 9      pgbench                     active SELECT 9
+0      pgbench                     active SELECT 0
 
 For 10 display lines, it should be at 8th line.
 
@@ -80,4 +82,6 @@ For 10 display lines, it should be at 8th line.
 7      pgbench                     active SELECT 7
 8      pgbench                     active SELECT 8
 9      pgbench                     active SELECT 9
+0      pgbench                     active SELECT 0
+1      pgbench                     active SELECT 1
 

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -971,9 +971,9 @@ PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                                               RUNNING QUERIES
 PID    DATABASE                      state   Query
-...    tests                 idle in trans   SELECT 43
 ...    tests                 idle in trans   UPDATE t SET s = 'blocking'
 ...    tests                        active   UPDATE t SET s = 'waiting'
+...    tests                 idle in trans   SELECT 43
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -997,9 +997,9 @@ PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                                               RUNNING QUERIES
 PID    DATABASE                      state   Query
-...    tests                 idle in trans   SELECT 43
 ...    tests                 idle in trans   UPDATE t SET s = 'blocking'
 ...    tests                        active   UPDATE t SET s = 'waiting'
+...    tests                 idle in trans   SELECT 43
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>


### PR DESCRIPTION
This is an alternative proposal to #257 which (in my opinion) produces a less strange behavior.

When scrolling through processes and the query is wrapped, there is no
way to compute an offset for the table rows in order to move the cursor.
Instead, when query is wrapped, we now always display focused process on
top of the table and we wrap around the processes list (display first
processes at the end of the table).

@blogh, what do you think?