### PR TITLE
Do not display 'None' values in processes table

### DIFF
--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -227,7 +227,9 @@ class Column:
     justify: str = attr.ib(
         "left", validator=validators.in_(["left", "center", "right"])
     )
-    transform: Callable[[Any], str] = attr.ib(default=str, repr=False)
+    transform: Callable[[Any], str] = attr.ib(
+        default=lambda v: str(v) if v is not None else "", repr=False
+    )
     color_key: Union[str, Callable[[Any], str]] = attr.ib(
         default=_color_key_marker, repr=False
     )

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -755,7 +755,7 @@ PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                                               WAITING QUERIES
 PID    DATABASE          RELATION             TYPE             MODE              state   Query
-...    tests                 None    transactionid        ShareLock             active   UPDATE t SET s = 'waiting'
+...    tests                         transactionid        ShareLock             active   UPDATE t SET s = 'waiting'
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -781,7 +781,7 @@ PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s
  Size: 106.07M - 0B/s ⋅ TPS: 0 ⋅ Active connections: 2 ⋅ Duration mode: query
                                                               BLOCKING QUERIES
 PID    DATABASE          RELATION             TYPE             MODE              state   Query
-...    tests                 None    transactionid    ExclusiveLock      idle in trans   UPDATE t SET s = 'blocking'
+...    tests                         transactionid    ExclusiveLock      idle in trans   UPDATE t SET s = 'blocking'
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>


### PR DESCRIPTION
Instead do not display anything (i.e. use an empty string when
rendering).