### PR TITLE
Activate the correct get_server_info SQL for v12/13

### DIFF
--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -203,6 +203,8 @@ class Data:
 
         if self.pg_num_version >= 140000:
             query = queries.get("get_server_info_post_140000")
+        elif self.pg_num_version >= 120000:
+            query = queries.get("get_server_info_post_120000")
         elif self.pg_num_version >= 110000:
             query = queries.get("get_server_info_post_110000")
         elif self.pg_num_version >= 100000:


### PR DESCRIPTION
Using old v11 SQL causes "permission denied for function pg_ls_dir" errors on managed Azure instances

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/krlc/git/postgres/pg_activity/pgactivity/__main__.py", line 4, in <module>
    main()
  File "/home/krlc/git/postgres/pg_activity/pgactivity/cli.py", line 327, in main
    ui.main(term, dataobj, host, args)
  File "/home/krlc/git/postgres/pg_activity/pgactivity/ui.py", line 29, in main
    server_information = data.pg_get_server_information(
  File "/home/krlc/git/postgres/pg_activity/pgactivity/data.py", line 225, in pg_get_server_information
    cur.execute(
  File "/usr/local/lib/python3.8/dist-packages/psycopg2/extras.py", line 146, in execute
    return super().execute(query, vars)
psycopg2.errors.InsufficientPrivilege: permission denied for function pg_ls_dir

```