### PR TITLE
Fix parallel workers under the lead process in UI via ORDER BY

### DIFF
--- a/pgactivity/queries/get_pg_activity_post_090600.sql
+++ b/pgactivity/queries/get_pg_activity_post_090600.sql
@@ -29,4 +29,4 @@ SELECT
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC, a.pid;

--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -31,4 +31,4 @@ SELECT
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC, a.pid;

--- a/pgactivity/queries/get_pg_activity_post_110000.sql
+++ b/pgactivity/queries/get_pg_activity_post_110000.sql
@@ -28,4 +28,4 @@ SELECT
         ELSE a.datname ~* %(dbname_filter)s
         END
 ORDER BY
-      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;
+      EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC, a.pid;


### PR DESCRIPTION
Currently they're jumping around annoyingly. Relevant for vers >= 9.6