### PR TITLE
Fix InvalidTextRepresentation

### DIFF
--- a/pgactivity/queries/get_blocking_oldest.sql
+++ b/pgactivity/queries/get_blocking_oldest.sql
@@ -17,7 +17,7 @@ SELECT
       END AS state,
       CASE WHEN sq.query LIKE '<IDLE>%%'
           THEN NULL
-          ELSE convert_from(sq.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
+          ELSE convert_from(replace(sq.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
       END AS query,
       waiting AS wait
   FROM

--- a/pgactivity/queries/get_blocking_post_090200.sql
+++ b/pgactivity/queries/get_blocking_post_090200.sql
@@ -13,7 +13,7 @@ SELECT
       locktype AS type,
       duration,
       state,
-      convert_from(sq.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      convert_from(replace(sq.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       waiting as wait
   FROM
       (

--- a/pgactivity/queries/get_blocking_post_090600.sql
+++ b/pgactivity/queries/get_blocking_post_090600.sql
@@ -11,7 +11,7 @@ SELECT
       locktype AS type,
       duration,
       state,
-      convert_from(sq.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      convert_from(replace(sq.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       wait_event as wait
   FROM
       (

--- a/pgactivity/queries/get_pg_activity_oldest.sql
+++ b/pgactivity/queries/get_pg_activity_oldest.sql
@@ -18,7 +18,7 @@ SELECT
       END AS state,
       CASE
           WHEN a.current_query LIKE '<IDLE>%%' THEN NULL
-          ELSE convert_from(a.current_query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
+          ELSE convert_from(replace(a.current_query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
       END AS query,
       false AS is_parallel_worker
   FROM

--- a/pgactivity/queries/get_pg_activity_post_090200.sql
+++ b/pgactivity/queries/get_pg_activity_post_090200.sql
@@ -13,7 +13,7 @@ SELECT
       a.waiting AS wait,
       a.usename AS user,
       a.state AS state,
-      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       false AS is_parallel_worker
   FROM
       pg_stat_activity a

--- a/pgactivity/queries/get_pg_activity_post_090600.sql
+++ b/pgactivity/queries/get_pg_activity_post_090600.sql
@@ -13,7 +13,7 @@ SELECT
       a.wait_event AS wait,
       a.usename AS user,
       a.state AS state,
-      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       false AS is_parallel_worker
   FROM
       pg_stat_activity a

--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -13,7 +13,7 @@ SELECT
       a.wait_event as wait,
       a.usename AS user,
       a.state AS state,
-      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       (   a.backend_type = 'background worker'
           AND a.query IS NOT NULL
       ) AS is_parallel_worker

--- a/pgactivity/queries/get_pg_activity_post_110000.sql
+++ b/pgactivity/queries/get_pg_activity_post_110000.sql
@@ -12,7 +12,7 @@ SELECT
       a.wait_event AS wait,
       a.usename AS user,
       a.state AS state,
-      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
       a.backend_type = 'parallel worker' AS is_parallel_worker
  FROM
       pg_stat_activity a

--- a/pgactivity/queries/get_waiting_oldest.sql
+++ b/pgactivity/queries/get_waiting_oldest.sql
@@ -20,7 +20,7 @@ SELECT
       END AS state,
       CASE WHEN a.current_query LIKE '<IDLE>%%'
           THEN NULL
-          ELSE convert_from(a.current_query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
+          ELSE convert_from(replace(a.current_query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
       END AS query
   FROM
       pg_catalog.pg_locks

--- a/pgactivity/queries/get_waiting_post_090200.sql
+++ b/pgactivity/queries/get_waiting_post_090200.sql
@@ -16,7 +16,7 @@ SELECT
       pg_locks.relation::regclass AS relation,
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       a.state as state,
-      convert_from(a.query::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query
+      convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query
   FROM
       pg_catalog.pg_locks
       JOIN pg_catalog.pg_stat_activity a ON(pg_catalog.pg_locks.pid = a.pid)


### PR DESCRIPTION
pg_activity crashes when queries use newlines or regexp as show in
issue https://github.com/dalibo/pg_activity/issues/275

This fix replaces single \ characters with double \ in the blocking,
waiting and activity queries.