### PR TITLE
Ignore all __pycache__ folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-build/
-htmlcov/
-dist/
-pg_activity.egg-info
-pgactivity/__pycache__/
 .coverage
-.vscode
 .tox
+.vscode
+__pycache__/
+build/
+dist/
+htmlcov/
+pg_activity.egg-info


### PR DESCRIPTION
Running `tox -p` command produced these supposed to be ignored folders:

pgactivity/queries/__pycache__/
tests/__pycache__/

We also sort the ignored list in .gitignore.