### PR TITLE
Add hint messages when features are disabled.

### DIFF
--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -1,4 +1,5 @@
 import getpass
+import logging
 import re
 from argparse import Namespace
 from typing import Dict, List, Optional
@@ -32,6 +33,9 @@ from .types import (
     NO_FILTER,
 )
 from .utils import clean_str
+
+
+logger = logging.getLogger("pgactivity")
 
 
 def pg_get_version(pg_conn: connection) -> str:
@@ -145,27 +149,41 @@ class Data:
         Verify if the user running pg_activity can access
         system information for the postmaster process.
         """
-        try:
-            query = queries.get("get_pid_file")
-            with self.pg_conn.cursor() as cur:
-                # This query doesn't crash when the user doesn't have the
-                # required privilege to acces the data_directory guc
-                # it will just return an empty string
+        query = queries.get("get_data_directory")
+        with self.pg_conn.cursor() as cur:
+            try:
                 cur.execute(query)
-                ret = cur.fetchone()
-            pid_file = ret["pid_file"]
+            except InsufficientPrivilege:
+                logger.info(
+                    "Insufficient privilege to show data_directory. System counters are disabled."
+                )
+                return False
+            ret = cur.fetchone()
+
+        pid_file = f"{ret['data_directory']}/postmaster.pid"
+        try:
             with open(pid_file, "r") as fd:
-                pid = fd.readlines()[0].strip()
-                try:
-                    proc = psutil.Process(int(pid))
-                    proc.io_counters()
-                    proc.cpu_times()
-                    return True
-                except psutil.AccessDenied:
-                    return False
-                except Exception:
-                    return False
-        except Exception:
+                pid = fd.readline().strip()
+        except PermissionError:
+            logger.info("Access Denied to the pidfile. System counters are disabled.")
+            return False
+
+        try:
+            proc = psutil.Process(int(pid))
+            proc.io_counters()
+            proc.cpu_times()
+            return True
+        except psutil.AccessDenied:
+            logger.info(
+                "Access denied to the psutil data. System counters are disabled."
+            )
+            return False
+        except AttributeError:
+            # See issue #300
+            logger.info(
+                "Your platform doesn't support some of psutil features required to get system counters. "
+                "System counters are disabled."
+            )
             return False
 
     def pg_cancel_backend(self, pid: int) -> bool:
@@ -216,6 +234,11 @@ class Data:
                 # superuser or pg_read_server_files are required (Issue #278)
                 cur.execute(queries.get("reset_statement_timeout"))
                 self.failed_queries.temp_file_query_failed = True
+                logger.info(
+                    "Insufficient privilege to fetch the tempfile data. "
+                    "The feature was disabled. Please use --no-tempfiles or a platform specific setting (eg. --rds)."
+                )
+
                 return None
             except QueryCanceled:
                 # if an excessive amount of tempfile exists, the query could be very long
@@ -223,6 +246,10 @@ class Data:
                 # refresh rate. This could end up spamming the PostgreSQL logs.
                 self.failed_queries.temp_file_query_failed = True
                 cur.execute(queries.get("reset_statement_timeout"))
+                logger.info(
+                    "The tempfile query ended in a timeout. "
+                    "The feature was disabled. Check the temporary files on the server."
+                )
                 return None
             cur.execute(queries.get("reset_statement_timeout"))
 
@@ -264,6 +291,10 @@ class Data:
         except FeatureNotSupported:
             # Not implemented on Aurora (Issue #301)
             self.failed_queries.wal_receivers_query_failed = True
+            logger.info(
+                "The receiver information is not available on your platform. "
+                "The feature is disabled. Please use the --no-walreceiver option."
+            )
             return None
 
         return int(ret["wal_receivers"])
@@ -315,15 +346,22 @@ class Data:
             query = queries.get("get_server_info_oldest")
 
         with self.pg_conn.cursor() as cur:
-            cur.execute(
-                query,
-                {
-                    "dbname_filter": self.filters.dbname,
-                    "skip_db_size": skip_db_size,
-                    "prev_total_size": prev_total_size,
-                    "using_rds": using_rds,
-                },
-            )
+            try:
+                cur.execute(
+                    query,
+                    {
+                        "dbname_filter": self.filters.dbname,
+                        "skip_db_size": skip_db_size,
+                        "prev_total_size": prev_total_size,
+                        "using_rds": using_rds,
+                    },
+                )
+            except InsufficientPrivilege:
+                logger.info(
+                    "Privileges might be insufficient to connect to a database. "
+                    "Try to use a --filter, the --no-db-size option or a platform specific setting (eg. --rds)"
+                )
+                raise
             ret = cur.fetchone()
 
         temporary_file_info: Optional[TempFileInfo] = None

--- a/pgactivity/queries/get_data_directory.sql
+++ b/pgactivity/queries/get_data_directory.sql
@@ -1,0 +1,2 @@
+-- Get the path of the pidfile
+SHOW data_directory;

--- a/pgactivity/queries/get_pid_file.sql
+++ b/pgactivity/queries/get_pid_file.sql
@@ -1,4 +1,0 @@
--- Get the path of the pidfile
-SELECT setting||'/postmaster.pid' AS pid_file
-  FROM pg_settings
- WHERE name = 'data_directory';


### PR DESCRIPTION
This patch adds hint messages to give feedback to the user when a
feature is disabled. Namely :

* tempfile (disabled because of privileges or timeout)
* wal receiver (disabled on Aurora because the feature not available)
* system counters (disabled because of lack of privilege, feature unavailable
  on Mac, access to the pid file)