### PR TITLE
Fix the parallel worker position in duration sort mode

### DIFF
--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -414,7 +414,9 @@ class Data:
         """
         Get activity from pg_stat_activity view.
         """
-        if self.pg_num_version >= 110000:
+        if self.pg_num_version >= 130000:
+            qs = queries.get("get_pg_activity_post_130000")
+        elif self.pg_num_version >= 110000:
             qs = queries.get("get_pg_activity_post_110000")
         elif self.pg_num_version >= 100000:
             qs = queries.get("get_pg_activity_post_100000")

--- a/pgactivity/queries/get_pg_activity_oldest.sql
+++ b/pgactivity/queries/get_pg_activity_oldest.sql
@@ -20,6 +20,7 @@ SELECT
           WHEN a.current_query LIKE '<IDLE>%%' THEN NULL
           ELSE convert_from(replace(a.current_query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8'))
       END AS query,
+      NULL AS query_leader_pid,
       false AS is_parallel_worker
   FROM
         pg_stat_activity a

--- a/pgactivity/queries/get_pg_activity_post_090200.sql
+++ b/pgactivity/queries/get_pg_activity_post_090200.sql
@@ -14,6 +14,7 @@ SELECT
       a.usename AS user,
       a.state AS state,
       convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      NULL AS query_leader_pid,
       false AS is_parallel_worker
   FROM
       pg_stat_activity a

--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -14,6 +14,7 @@ SELECT
       a.usename AS user,
       a.state AS state,
       convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      NULL AS query_leader_pid,
       (   a.backend_type = 'background worker'
           AND a.query IS NOT NULL
       ) AS is_parallel_worker

--- a/pgactivity/queries/get_pg_activity_post_110000.sql
+++ b/pgactivity/queries/get_pg_activity_post_110000.sql
@@ -13,6 +13,7 @@ SELECT
       a.usename AS user,
       a.state AS state,
       convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
+      NULL AS query_leader_pid,
       a.backend_type = 'parallel worker' AS is_parallel_worker
  FROM
       pg_stat_activity a

--- a/pgactivity/queries/get_pg_activity_post_130000.sql
+++ b/pgactivity/queries/get_pg_activity_post_130000.sql
@@ -1,6 +1,5 @@
--- Get data from pg_activity from pg 9.6 to 10
--- In this version there is no way to distinguish parallel workers from the rest
--- NEW pg_stat_activity.waiting => pg_stat_activity.wait_event
+-- Get data from pg_activity since pg 13
+-- NEW pg_activity.leader_pid
 SELECT
       a.pid AS pid,
       a.application_name AS application_name,
@@ -14,20 +13,20 @@ SELECT
       a.usename AS user,
       a.state AS state,
       convert_from(replace(a.query, '\', '\\')::bytea, coalesce(pg_catalog.pg_encoding_to_char(b.encoding), 'UTF8')) AS query,
-      NULL AS query_leader_pid,
-      false AS is_parallel_worker
-  FROM
+      coalesce(a.leader_pid, a.pid) AS query_leader_pid,
+      a.backend_type = 'parallel worker' AS is_parallel_worker
+ FROM
       pg_stat_activity a
       LEFT OUTER JOIN pg_database b ON a.datid = b.oid
  WHERE
-      state <> 'idle'
-  AND pid <> pg_backend_pid()
+      a.state <> 'idle'
+  AND a.pid <> pg_catalog.pg_backend_pid()
   AND CASE WHEN %(min_duration)s = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-  AND CASE WHEN %(dbname_filter)s IS NULL THEN true
-      ELSE a.datname ~* %(dbname_filter)s
-      END
+    AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        ELSE a.datname ~* %(dbname_filter)s
+        END
 ORDER BY
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) DESC;

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -893,6 +893,7 @@ class BaseProcess:
     duration: Optional[float]
     state: str
     query: Optional[str]
+    query_leader_pid: Optional[int]
     is_parallel_worker: bool
 
 
@@ -901,6 +902,7 @@ class RunningProcess(BaseProcess):
     """Process for a running query."""
 
     wait: Union[bool, None, str]
+    query_leader_pid: Optional[int]
     is_parallel_worker: bool
 
 
@@ -914,7 +916,8 @@ class WaitingProcess(BaseProcess):
     type: LockType = attr.ib(converter=locktype)
     relation: str
 
-    # TODO: update queries to select/compute this column.
+    # TODO: update queries to select/compute these column.
+    query_leader_pid: Optional[int] = attr.ib(default=None, init=False)
     is_parallel_worker: bool = attr.ib(default=False, init=False)
 
 
@@ -929,7 +932,8 @@ class BlockingProcess(BaseProcess):
     relation: str
     wait: Union[bool, None, str]
 
-    # TODO: update queries to select/compute this column.
+    # TODO: update queries to select/compute these column.
+    query_leader_pid: Optional[int] = attr.ib(default=None, init=False)
     is_parallel_worker: bool = attr.ib(default=False, init=False)
 
 

--- a/tests/data/local-processes-input.json
+++ b/tests/data/local-processes-input.json
@@ -42,6 +42,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6221,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6221,
@@ -93,6 +94,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6222,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6222,
@@ -144,6 +146,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6223,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6223,
@@ -195,6 +198,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6224,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6224,
@@ -246,6 +250,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6225,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6225,
@@ -297,6 +302,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6226,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6226,
@@ -348,6 +354,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6227,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6227,
@@ -399,6 +406,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6228,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6228,
@@ -450,6 +458,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6229,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6229,
@@ -501,6 +510,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6230,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6230,
@@ -552,6 +562,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6231,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6231,
@@ -603,6 +614,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6232,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6232,
@@ -654,6 +666,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6233,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6233,
@@ -705,6 +718,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6234,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6234,
@@ -756,6 +770,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6235,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6235,
@@ -807,6 +822,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6237,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6237,
@@ -858,6 +874,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6238,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6238,
@@ -909,6 +926,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6239,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6239,
@@ -960,6 +978,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6240,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6240,
@@ -1013,6 +1032,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6221,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6221,
@@ -1064,6 +1084,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6222,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6222,
@@ -1115,6 +1136,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6223,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6223,
@@ -1166,6 +1188,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6224,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6224,
@@ -1217,6 +1240,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6225,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6225,
@@ -1268,6 +1292,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6226,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6226,
@@ -1319,6 +1344,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6227,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6227,
@@ -1370,6 +1396,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6228,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6228,
@@ -1421,6 +1448,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6229,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6229,
@@ -1472,6 +1500,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6230,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6230,
@@ -1523,6 +1552,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6231,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6231,
@@ -1574,6 +1604,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6232,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6232,
@@ -1625,6 +1656,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6233,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6233,
@@ -1676,6 +1708,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6234,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6234,
@@ -1727,6 +1760,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6235,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6235,
@@ -1778,6 +1812,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6236,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6236,
@@ -1829,6 +1864,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6237,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6237,
@@ -1880,6 +1916,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6238,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6238,
@@ -1931,6 +1968,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6239,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6239,
@@ -1982,6 +2020,7 @@
                 "read_delta": 0.0,
                 "write_delta": 0.0
             },
+	    "query_leader_pid": 6240,
             "is_parallel_worker": false,
             "mem": null,
             "pid": 6240,

--- a/tests/test_scroll.txt
+++ b/tests/test_scroll.txt
@@ -20,6 +20,7 @@ Tests scrolling in processes_rows()
 ...         query=f"SELECT {x}",
 ...         duration=0.0,
 ...         wait=False,
+...         query_leader_pid=x,
 ...         is_parallel_worker=False,
 ...     ) for x in range(0, 10)]
 >>> ui = UI.make(flag=Flag.PID|Flag.DATABASE)

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -203,6 +203,7 @@ Tests for processes_rows()
 ...         duration=0.0,
 ...         wait=False,
 ...         io_wait=False,
+...         query_leader_pid=6239,
 ...         is_parallel_worker=False,
 ...     ),
 ...     LocalRunningProcess(
@@ -216,10 +217,11 @@ Tests for processes_rows()
 ...         read=0.2,
 ...         write=1_128_201,
 ...         state="active",
-...         query="UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;",
+...         query="UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;",
 ...         duration=0.000413,
 ...         wait=None,
 ...         io_wait=True,
+...         query_leader_pid=6239,
 ...         is_parallel_worker=True,
 ...     ),
 ...     LocalRunningProcess(
@@ -237,6 +239,7 @@ Tests for processes_rows()
 ...         duration=1234,
 ...         wait="BackendRandomLock",
 ...         io_wait=False,
+...         query_leader_pid=1234,
 ...         is_parallel_worker=False,
 ...     ),
 ... ]
@@ -254,8 +257,8 @@ Tests for processes_rows()
                                                        141 WHERE aid = 1932841;
 6228   pgbench          0.2    1.0             active \_ UPDATE
                                                        pgbench_accounts SET
-                                                       abalance = abalance +
-                                                       3062 WHERE aid = 7289374;
+                                                       abalance = abalance + 141
+                                                       WHERE aid = 1932841;
 1234   business         2.4    1.0             active SELECT product_id, p.name
                                                        FROM products p LEFT JOIN
                                                        sales s USING
@@ -276,7 +279,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 (TODO: this is buggy, the first line should be wrapped as well if too long)
 >>> processes_rows(term, ui, SelectableProcesses(processes1), 100, width=250)
 6239   pgbench                   pgbench         postgres            local 0.1    1.0  7B       12B       0.000000                N N        idle in trans UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
-6228   pgbench                   pgbench         postgres            local 0.2    1.0  0B       1.08M     0.000413                  Y               active \_ UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;
+6228   pgbench                   pgbench         postgres            local 0.2    1.0  0B       1.08M     0.000413                  Y               active \_ UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
 1234   business               accounting              bob            local 2.4    1.0  9.42M    1.21K     20:34.00 BackendRandomLoc N               active SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date >
 
 >>> ui = UI.make(flag=Flag.PID|Flag.DATABASE, wrap_query=False)
@@ -290,8 +293,8 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 6239   pgbench              idle in trans UPDATE pgbench_accounts SET abalance
                                            = abalance + 141 WHERE aid = 1932841;
 6228   pgbench                     active \_ UPDATE pgbench_accounts SET
-                                           abalance = abalance + 3062 WHERE aid
-                                           = 7289374;
+                                           abalance = abalance + 141 WHERE aid =
+					   1932841;
 1234   business                    active SELECT product_id, p.name FROM
                                            products p LEFT JOIN sales s USING
                                            (product_id) WHERE s.date >
@@ -352,6 +355,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         query="UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;",
 ...         duration=0.0,
 ...         wait=False,
+...         query_leader_pid=6239,
 ...         is_parallel_worker=False,
 ...     ),
 ...     RunningProcess(
@@ -361,9 +365,10 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         user="postgres",
 ...         client="local",
 ...         state="active",
-...         query="UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;",
+...         query="UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;",
 ...         duration=0.000413,
 ...         wait=True,
+...         query_leader_pid=6239,
 ...         is_parallel_worker=True,
 ...     ),
 ...     RunningProcess(
@@ -376,6 +381,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         query="SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date > CURRENT_DATE - INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;",
 ...         duration=1234,
 ...         wait="clog",
+...         query_leader_pid=1234,
 ...         is_parallel_worker=False,
 ...     ),
 ... ]
@@ -383,7 +389,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 >>> ui = UI.make(query_mode=QueryMode.activities,flag=all_but_local_flags)
 >>> processes_rows(term, ui, SelectableProcesses(processes1b), 100, width=200)
 6239   pgbench                   pgbench         postgres            local  0.000000                N     idle in trans UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
-6228   pgbench                      none         postgres            local  0.000413                Y            active \_ UPDATE pgbench_accounts SET abalance = abalance + 3062 WHERE aid = 7289374;
+6228   pgbench                      none         postgres            local  0.000413                Y            active \_ UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
 1234   business               accounting              bob     192.168.0.47  20:34.00             clog            active SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id)
 
 Tests for footer_*()


### PR DESCRIPTION
We now sort by `query_leader_pid` ASC, `is_parallel_worker` ASC in
addition to `duration` DESC.

`query_leader_pid` is a crafted column:
* pre pg13, it's always `NULL`, the tuple order will still depend on the
  order in witch the tuple are fetched;
* for pg13 and after, it's equal to `coaelesce(leader_pid, pid)` which
  should fix the display.

Fix some tests which displayed different queries for a leader and it's
worker processes.

closes #297 