### PR TITLE
Fix .flake8 for fake8 6.0.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,12 @@
 [flake8]
 doctests = True
 ignore =
-  E203, # whitespace before ‘:’
-  E501, # line too long
-  W503, # line break before binary operator
+  # whitespace before ‘:’
+  E203,
+  # line too long
+  E501,
+  # line break before binary operator
+  W503,
 exclude =
   .git,
   .mypy_cache,


### PR DESCRIPTION
This backwards incompatible change was made in version 6.0.0 of flake8.

* Produce an error when invalid codes are specified in configuration (See also #1689, #1713).

see: https://github.com/pycqa/flake8/issues/1689#issuecomment-1326319235