### PR TITLE
Work around a mypy bug with Python 3.11

### DIFF
--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -885,6 +885,8 @@ class LockType(enum.Enum):
 
     def __str__(self) -> str:
         # Custom str(self) for transparent rendering in views.
+        assert isinstance(self.name, str)
+        # TODO ^ remove this assert for mypy > 0.991
         return self.name
 
 


### PR DESCRIPTION
Mypy (many versions) raises a wrong error for Python 3.11:

  pgactivity/types.py:888: error: Returning Any from function declared to return "str"  [no-any-return]

Should be fixed by commit:

  https://github.com/python/mypy/commit/05a3f7d8d61bc298809e5363d3a23aa16fe776d2