### PR TITLE
Add test for #275

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -137,6 +137,13 @@ def test_encoding(postgresql, data, execute):
     assert "blocking éléphant" in blocking.query
 
 
+def test_InvalidTextRepresentation(postgresql, data, execute):
+    """Test for issue #275"""
+    postgresql.execute("select '123' ~ '\\d+', 'Hello world!\n', pg_sleep(3)")
+    running = data.pg_get_activities()
+    assert "123" in running[0].query
+
+
 def test_filters_dbname(data, execute):
     data_filtered = attr.evolve(data, filters=types.Filters(dbname="temp"))
     execute("SELECT pg_sleep(2)", dbname="template1", autocommit=True)


### PR DESCRIPTION
This test will ensure we still to handle queries without throwing this exception :

psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type bytea