### PR TITLE
add support for psycopg 3

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,2 @@
 [codespell]
-skip = .git,.mypy_cache,.tox,.venv,htmlcov
+skip = .git,.mypy_cache,.tox,.venv,build,htmlcov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,13 @@ jobs:
       matrix:
         include:
           - python: "3.7"
+            psycopg: "psycopg2"
           - python: "3.8"
+            psycopg: "psycopg3"
           - python: "3.9"
+            psycopg: "psycopg2"
           - python: "3.10"
+            psycopg: "psycopg3"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -25,4 +29,4 @@ jobs:
            sudo locale-gen fr_FR
            sudo update-locale
       - name: Test
-        run: tox -e py
+        run: tox -e py-${{ matrix.psycopg }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## **Unreleased**
 
+### Added
+
+* Add support for Psycopg 3 database driver, as an alternative to psycopg2.
+  Packagers and users installing from `pip` are encouraged to install the
+  `psycopg` dependency instead of psycopg2.
+* Add `psycopg` and `psycopg2` setuptools extras to ease complete installation
+  from pip.
+
 ### Fixed
 
 * Fix a few typos in the man page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use [codespell](https://github.com/codespell-project/codespell) to check
   misspellings.
 * Add Project-URLs core metadata for Python packaging.
+* Install the project in *develop* mode in Tox test environment.
 
 ## pg\_activity 3.0.2  - 2023-01-17
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Installation from pip
 ---------------------
 
 Alternatively, pg\_activity can be installed using pip on Python 3.7 or later
-along with psycopg2 (version 2.8 or higher):
+along with psycopg:
 
-    $ python3 -m pip install pg_activity psycopg2-binary
+    $ python3 -m pip install "pg_activity[psycopg]"
 
 In case your `$PATH` does not already contain it, the full path is:
 
@@ -42,12 +42,12 @@ This is only necessary to test development versions. First, clone the repository
     $ git clone https://github.com/dalibo/pg_activity.git
 
 Change the branch if necessary. Then create a dedicated environment,
-install dependencies and then pg\_activity from the repo:
+and install pg\_activity with the psycopg database driver:
 
     $ cd pg_activity
     $ python3 -m venv .venv
     $ . .venv/bin/activate
-    (.venv) $ pip install psycopg2-binary .
+    (.venv) $ pip install ".[psycopg]"
     (.venv) $ pg_activity
 
 To quit this env and destroy it:

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -8,9 +8,9 @@ from io import StringIO
 from typing import Optional
 
 from blessed import Terminal
-from psycopg2.errors import OperationalError
 
 from . import __version__, data, types, ui
+from .pg import OperationalError
 
 
 def configure_logger(debug_file: Optional[str] = None) -> StringIO:

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -231,7 +231,9 @@ class Data:
 
         with self.pg_conn.cursor() as cur:
             try:
-                cur.execute(queries.get("set_statement_timeout"), {"timeout": "400ms"})
+                cur.execute(
+                    sql.SQL("SET statement_timeout TO {}").format(sql.Literal("400ms"))
+                )
                 cur.execute(query)
                 ret = cur.fetchone()
             except InsufficientPrivilege:

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -238,7 +238,6 @@ class Data:
                 ret = cur.fetchone()
             except InsufficientPrivilege:
                 # superuser or pg_read_server_files are required (Issue #278)
-                cur.execute(queries.get("reset_statement_timeout"))
                 self.failed_queries.temp_file_query_failed = True
                 logger.info(
                     "Insufficient privilege to fetch the tempfile data. "
@@ -251,13 +250,13 @@ class Data:
                 # to avoid such a case we set a statement_timeout shorter than the lowest
                 # refresh rate. This could end up spamming the PostgreSQL logs.
                 self.failed_queries.temp_file_query_failed = True
-                cur.execute(queries.get("reset_statement_timeout"))
                 logger.info(
                     "The tempfile query ended in a timeout. "
                     "The feature was disabled. Check the temporary files on the server."
                 )
                 return None
-            cur.execute(queries.get("reset_statement_timeout"))
+            finally:
+                cur.execute(queries.get("reset_statement_timeout"))
 
         return TempFileInfo(**ret)
 

--- a/pgactivity/pg.py
+++ b/pgactivity/pg.py
@@ -1,0 +1,68 @@
+from typing import Any, Dict, List, Sequence, Union
+
+import psycopg2
+from psycopg2.extras import DictCursor
+from psycopg2 import sql as sql
+from psycopg2.errors import (
+    FeatureNotSupported as FeatureNotSupported,
+    InterfaceError as InterfaceError,
+    InvalidPassword as InvalidPassword,
+    InsufficientPrivilege as InsufficientPrivilege,
+    OperationalError as OperationalError,
+    ProgrammingError as ProgrammingError,
+    QueryCanceled as QueryCanceled,
+)
+
+from psycopg2.extensions import connection as Connection
+
+
+def connect(*args: Any, **kwargs: Any) -> Connection:
+    return psycopg2.connect(*args, cursor_factory=DictCursor, **kwargs)
+
+
+def execute(
+    conn: Connection,
+    query: str,
+    args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(query, args)
+
+
+def fetchone(
+    conn: Connection,
+    query: str,
+    args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    with conn.cursor() as cur:
+        cur.execute(query, args)
+        row = cur.fetchone()
+    assert row is not None
+    return row  # type: ignore[no-any-return]
+
+
+def fetchall(
+    conn: Connection,
+    query: str,
+    args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(query, args)
+        return cur.fetchall()  # type: ignore[no-any-return]
+
+
+__all__ = [
+    "Connection",
+    "FeatureNotSupported",
+    "InterfaceError",
+    "InvalidPassword",
+    "InsufficientPrivilege",
+    "OperationalError",
+    "ProgrammingError",
+    "QueryCanceled",
+    "connect",
+    "execute",
+    "fetchall",
+    "fetchone",
+    "sql",
+]

--- a/pgactivity/pg.py
+++ b/pgactivity/pg.py
@@ -1,57 +1,123 @@
+import os
 from typing import Any, Dict, List, Sequence, Union
 
-import psycopg2
-from psycopg2.extras import DictCursor
-from psycopg2 import sql as sql
-from psycopg2.errors import (
-    FeatureNotSupported as FeatureNotSupported,
-    InterfaceError as InterfaceError,
-    InvalidPassword as InvalidPassword,
-    InsufficientPrivilege as InsufficientPrivilege,
-    OperationalError as OperationalError,
-    ProgrammingError as ProgrammingError,
-    QueryCanceled as QueryCanceled,
-)
+try:
+    if "_PGACTIVITY_USE_PSYCOPG2" in os.environ:
+        raise ImportError("psycopg2 requested from environment")
 
-from psycopg2.extensions import connection as Connection
+    import psycopg
+    from psycopg import sql as sql
+    from psycopg.rows import dict_row
+    from psycopg.errors import (
+        FeatureNotSupported as FeatureNotSupported,
+        InterfaceError as InterfaceError,
+        InvalidPassword as InvalidPassword,
+        InsufficientPrivilege as InsufficientPrivilege,
+        OperationalError as OperationalError,
+        ProgrammingError as ProgrammingError,
+        QueryCanceled as QueryCanceled,
+    )
 
+    __version__ = psycopg.__version__
 
-def connect(*args: Any, **kwargs: Any) -> Connection:
-    return psycopg2.connect(*args, cursor_factory=DictCursor, **kwargs)
+    Connection = psycopg.Connection[Dict[str, Any]]
 
+    def connect(*args: Any, **kwargs: Any) -> Connection:
+        return psycopg.connect(*args, autocommit=True, row_factory=dict_row, **kwargs)
 
-def execute(
-    conn: Connection,
-    query: str,
-    args: Union[None, Sequence[Any], Dict[str, Any]] = None,
-) -> None:
-    with conn.cursor() as cur:
-        cur.execute(query, args)
+    def server_version(conn: Connection) -> int:
+        return conn.info.server_version
 
+    def connection_parameters(conn: Connection) -> Dict[str, Any]:
+        return conn.info.get_parameters()
 
-def fetchone(
-    conn: Connection,
-    query: str,
-    args: Union[None, Sequence[Any], Dict[str, Any]] = None,
-) -> Dict[str, Any]:
-    with conn.cursor() as cur:
-        cur.execute(query, args)
-        row = cur.fetchone()
-    assert row is not None
-    return row  # type: ignore[no-any-return]
+    def execute(
+        conn: Connection,
+        query: Union[str, sql.Composed],
+        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+    ) -> None:
+        conn.execute(query, args)
 
+    def fetchone(
+        conn: Connection,
+        query: Union[str, sql.Composed],
+        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        row = conn.execute(query, args).fetchone()
+        assert row is not None
+        return row
 
-def fetchall(
-    conn: Connection,
-    query: str,
-    args: Union[None, Sequence[Any], Dict[str, Any]] = None,
-) -> List[Dict[str, Any]]:
-    with conn.cursor() as cur:
-        cur.execute(query, args)
-        return cur.fetchall()  # type: ignore[no-any-return]
+    def fetchall(
+        conn: Connection,
+        query: Union[str, sql.Composed],
+        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        return conn.execute(query, args).fetchall()
+
+except ImportError:
+    import psycopg2
+    from psycopg2.extras import DictCursor
+    from psycopg2 import sql as sql  # type: ignore[no-redef]
+    from psycopg2.errors import (  # type: ignore[no-redef]
+        FeatureNotSupported as FeatureNotSupported,
+        InterfaceError as InterfaceError,
+        InvalidPassword as InvalidPassword,
+        InsufficientPrivilege as InsufficientPrivilege,
+        OperationalError as OperationalError,
+        ProgrammingError as ProgrammingError,
+        QueryCanceled as QueryCanceled,
+    )
+
+    from psycopg2.extensions import connection as Connection  # type: ignore[no-redef]
+
+    __version__ = psycopg2.__version__
+
+    def connect(*args: Any, **kwargs: Any) -> Connection:
+        try:
+            kwargs.setdefault("database", kwargs.pop("dbname"))
+        except KeyError:
+            pass
+        conn = psycopg2.connect(*args, cursor_factory=DictCursor, **kwargs)
+        conn.autocommit = True
+        return conn  # type: ignore[no-any-return]
+
+    def server_version(conn: Connection) -> int:
+        return conn.server_version  # type: ignore[attr-defined, no-any-return]
+
+    def connection_parameters(conn: Connection) -> Dict[str, Any]:
+        return conn.info.dsn_parameters  # type: ignore[attr-defined, no-any-return]
+
+    def execute(
+        conn: Connection,
+        query: Union[str, sql.Composed],
+        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+    ) -> None:
+        with conn.cursor() as cur:
+            cur.execute(query, args)
+
+    def fetchone(
+        conn: Connection,
+        query: Union[str, sql.Composed],
+        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        with conn.cursor() as cur:
+            cur.execute(query, args)
+            row = cur.fetchone()
+        assert row is not None
+        return row
+
+    def fetchall(
+        conn: Connection,
+        query: Union[str, sql.Composed],
+        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        with conn.cursor() as cur:
+            cur.execute(query, args)
+            return cur.fetchall()
 
 
 __all__ = [
+    "__version__",
     "Connection",
     "FeatureNotSupported",
     "InterfaceError",
@@ -61,8 +127,10 @@ __all__ = [
     "ProgrammingError",
     "QueryCanceled",
     "connect",
+    "connection_parameters",
     "execute",
     "fetchall",
     "fetchone",
+    "server_version",
     "sql",
 ]

--- a/pgactivity/queries/get_blocking_oldest.sql
+++ b/pgactivity/queries/get_blocking_oldest.sql
@@ -47,11 +47,11 @@ SELECT
        WHERE
             blocking.granted
         AND NOT blocked.granted
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       UNION ALL
@@ -80,11 +80,11 @@ SELECT
        WHERE
             blocking.granted
         AND NOT blocked.granted
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       UNION ALL
@@ -114,11 +114,11 @@ SELECT
             blocking.granted
         AND NOT blocked.granted
         AND blocked.relation IS NOT NULL
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       ) AS sq

--- a/pgactivity/queries/get_blocking_post_090200.sql
+++ b/pgactivity/queries/get_blocking_post_090200.sql
@@ -42,11 +42,11 @@ SELECT
        WHERE
             blocking.granted
         AND NOT blocked.granted
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       UNION ALL
@@ -75,11 +75,11 @@ SELECT
        WHERE
             blocking.granted
         AND NOT blocked.granted
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       UNION ALL
@@ -109,11 +109,11 @@ SELECT
             blocking.granted
         AND NOT blocked.granted
         AND blocked.relation IS NOT NULL
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       ) AS sq

--- a/pgactivity/queries/get_blocking_post_090600.sql
+++ b/pgactivity/queries/get_blocking_post_090600.sql
@@ -40,11 +40,11 @@ SELECT
        WHERE
             blocking.granted
         AND NOT blocked.granted
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       UNION ALL
@@ -73,11 +73,11 @@ SELECT
        WHERE
             blocking.granted
         AND NOT blocked.granted
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       UNION ALL
@@ -107,11 +107,11 @@ SELECT
             blocking.granted
         AND NOT blocked.granted
         AND blocked.relation IS NOT NULL
-        AND CASE WHEN %(min_duration)s = 0
+        AND CASE WHEN {min_duration} = 0
                 THEN true
                 ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
             END
-        AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+        AND CASE WHEN {dbname_filter} IS NULL THEN true
             ELSE datname ~* %(dbname_filter)s
             END
       ) AS sq

--- a/pgactivity/queries/get_pg_activity_oldest.sql
+++ b/pgactivity/queries/get_pg_activity_oldest.sql
@@ -28,11 +28,11 @@ SELECT
  WHERE
       current_query <> '<IDLE>'
   AND procpid <> pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-  AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+  AND CASE WHEN {dbname_filter} IS NULL THEN true
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY

--- a/pgactivity/queries/get_pg_activity_post_090200.sql
+++ b/pgactivity/queries/get_pg_activity_post_090200.sql
@@ -22,11 +22,11 @@ SELECT
  WHERE
       state <> 'idle'
   AND pid <> pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-  AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+  AND CASE WHEN {dbname_filter} IS NULL THEN true
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY

--- a/pgactivity/queries/get_pg_activity_post_090600.sql
+++ b/pgactivity/queries/get_pg_activity_post_090600.sql
@@ -22,11 +22,11 @@ SELECT
  WHERE
       state <> 'idle'
   AND pid <> pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-  AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+  AND CASE WHEN {dbname_filter} IS NULL THEN true
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY

--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -24,11 +24,11 @@ SELECT
  WHERE
       state <> 'idle'
   AND pid <> pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-  AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+  AND CASE WHEN {dbname_filter} IS NULL THEN true
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY

--- a/pgactivity/queries/get_pg_activity_post_110000.sql
+++ b/pgactivity/queries/get_pg_activity_post_110000.sql
@@ -21,11 +21,11 @@ SELECT
  WHERE
       a.state <> 'idle'
   AND a.pid <> pg_catalog.pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-    AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+    AND CASE WHEN {dbname_filter} IS NULL THEN true
         ELSE a.datname ~* %(dbname_filter)s
         END
 ORDER BY

--- a/pgactivity/queries/get_pg_activity_post_130000.sql
+++ b/pgactivity/queries/get_pg_activity_post_130000.sql
@@ -21,11 +21,11 @@ SELECT
  WHERE
       a.state <> 'idle'
   AND a.pid <> pg_catalog.pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-    AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+    AND CASE WHEN {dbname_filter} IS NULL THEN true
         ELSE a.datname ~* %(dbname_filter)s
         END
 ORDER BY

--- a/pgactivity/queries/get_server_info_oldest.sql
+++ b/pgactivity/queries/get_server_info_oldest.sql
@@ -17,7 +17,7 @@ WITH dbinfo AS(
           FROM pg_database d
                INNER JOIN pg_stat_database sd ON d.oid = sd.datid
          WHERE NOT (d.datname = 'rdsadmin' AND %(using_rds)s)
-               AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+               AND CASE WHEN {dbname_filter} IS NULL THEN true
                         ELSE d.datname ~* %(dbname_filter)s
                    END
 ), activity AS (
@@ -38,7 +38,7 @@ WITH dbinfo AS(
                NULL AS max_wal_senders,
                NULL AS max_replication_slots
           FROM pg_stat_activity
-         WHERE CASE WHEN %(dbname_filter)s IS NULL THEN true
+         WHERE CASE WHEN {dbname_filter} IS NULL THEN true
                     ELSE datname ~* %(dbname_filter)s
                END
 )

--- a/pgactivity/queries/get_server_info_post_090100.sql
+++ b/pgactivity/queries/get_server_info_post_090100.sql
@@ -18,7 +18,7 @@ WITH dbinfo AS(
           FROM pg_database d
                INNER JOIN pg_stat_database sd ON d.oid = sd.datid
          WHERE NOT (d.datname = 'rdsadmin' AND %(using_rds)s)
-               AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+               AND CASE WHEN {dbname_filter} IS NULL THEN true
                         ELSE d.datname ~* %(dbname_filter)s
                    END
 ), activity AS (
@@ -39,7 +39,7 @@ WITH dbinfo AS(
                current_setting('max_wal_senders')::int AS max_wal_senders,
                NULL AS max_replication_slots
           FROM pg_stat_activity
-         WHERE CASE WHEN %(dbname_filter)s IS NULL THEN true
+         WHERE CASE WHEN {dbname_filter} IS NULL THEN true
                     ELSE datname ~* %(dbname_filter)s
                END
 )

--- a/pgactivity/queries/get_server_info_post_090200.sql
+++ b/pgactivity/queries/get_server_info_post_090200.sql
@@ -18,7 +18,7 @@ WITH dbinfo AS(
           FROM pg_database d
                INNER JOIN pg_stat_database sd ON d.oid = sd.datid
          WHERE NOT (d.datname = 'rdsadmin' AND %(using_rds)s)
-               AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+               AND CASE WHEN {dbname_filter} IS NULL THEN true
                         ELSE d.datname ~* %(dbname_filter)s
                    END
 ), activity AS (
@@ -39,7 +39,7 @@ WITH dbinfo AS(
                current_setting('max_wal_senders')::int AS max_wal_senders,
                NULL AS max_replication_slots
           FROM pg_stat_activity
-         WHERE CASE WHEN %(dbname_filter)s IS NULL THEN true
+         WHERE CASE WHEN {dbname_filter} IS NULL THEN true
                     ELSE datname ~* %(dbname_filter)s
                END
 )

--- a/pgactivity/queries/get_server_info_post_090400.sql
+++ b/pgactivity/queries/get_server_info_post_090400.sql
@@ -21,7 +21,7 @@ WITH dbinfo AS(
           FROM pg_database d
                INNER JOIN pg_stat_database sd ON d.oid = sd.datid
          WHERE NOT (d.datname = 'rdsadmin' AND %(using_rds)s)
-               AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+               AND CASE WHEN {dbname_filter} IS NULL THEN true
                         ELSE d.datname ~* %(dbname_filter)s
                    END
 ), activity AS (
@@ -42,7 +42,7 @@ WITH dbinfo AS(
                current_setting('max_wal_senders')::int AS max_wal_senders,
                current_setting('max_replication_slots')::int AS max_replication_slots
           FROM pg_stat_activity
-         WHERE CASE WHEN %(dbname_filter)s IS NULL THEN true
+         WHERE CASE WHEN {dbname_filter} IS NULL THEN true
                     ELSE datname ~* %(dbname_filter)s
                END
 )

--- a/pgactivity/queries/get_server_info_post_090600.sql
+++ b/pgactivity/queries/get_server_info_post_090600.sql
@@ -19,7 +19,7 @@ WITH dbinfo AS(
           FROM pg_database d
                INNER JOIN pg_stat_database sd ON d.oid = sd.datid
          WHERE NOT (d.datname = 'rdsadmin' AND %(using_rds)s)
-               AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+               AND CASE WHEN {dbname_filter} IS NULL THEN true
                         ELSE d.datname ~* %(dbname_filter)s
                    END
 ), activity AS (
@@ -40,7 +40,7 @@ WITH dbinfo AS(
                current_setting('max_wal_senders')::int AS max_wal_senders,
                current_setting('max_replication_slots')::int AS max_replication_slots
           FROM pg_stat_activity
-         WHERE CASE WHEN %(dbname_filter)s IS NULL THEN true
+         WHERE CASE WHEN {dbname_filter} IS NULL THEN true
                     ELSE datname ~* %(dbname_filter)s
                END
 )

--- a/pgactivity/queries/get_server_info_post_100000.sql
+++ b/pgactivity/queries/get_server_info_post_100000.sql
@@ -20,7 +20,7 @@ WITH dbinfo AS(
           FROM pg_database d
                INNER JOIN pg_stat_database sd ON d.oid = sd.datid
          WHERE NOT (d.datname = 'rdsadmin' AND %(using_rds)s)
-               AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+               AND CASE WHEN {dbname_filter} IS NULL THEN true
                         ELSE d.datname ~* %(dbname_filter)s
                   END
 ), activity AS (
@@ -41,7 +41,7 @@ WITH dbinfo AS(
                current_setting('max_wal_senders')::int AS max_wal_senders,
                current_setting('max_replication_slots')::int AS max_replication_slots
           FROM pg_stat_activity
-         WHERE CASE WHEN %(dbname_filter)s IS NULL THEN true
+         WHERE CASE WHEN {dbname_filter} IS NULL THEN true
                     ELSE datname ~* %(dbname_filter)s
                END
 )

--- a/pgactivity/queries/get_server_info_post_110000.sql
+++ b/pgactivity/queries/get_server_info_post_110000.sql
@@ -18,7 +18,7 @@ WITH dbinfo AS(
           FROM pg_database d
                INNER JOIN pg_stat_database sd ON d.oid = sd.datid
          WHERE NOT (d.datname = 'rdsadmin' AND %(using_rds)s)
-               AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+               AND CASE WHEN {dbname_filter} IS NULL THEN true
                         ELSE d.datname ~* %(dbname_filter)s
                    END
 ), activity AS (
@@ -39,7 +39,7 @@ WITH dbinfo AS(
                current_setting('max_wal_senders')::int AS max_wal_senders,
                current_setting('max_replication_slots')::int AS max_replication_slots
           FROM pg_stat_activity
-         WHERE CASE WHEN %(dbname_filter)s IS NULL THEN true
+         WHERE CASE WHEN {dbname_filter} IS NULL THEN true
                     ELSE datname ~* %(dbname_filter)s
                END
 )

--- a/pgactivity/queries/get_waiting_oldest.sql
+++ b/pgactivity/queries/get_waiting_oldest.sql
@@ -29,11 +29,11 @@ SELECT
  WHERE
       NOT pg_catalog.pg_locks.granted
   AND a.procpid <> pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-  AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+  AND CASE WHEN {dbname_filter} IS NULL THEN true
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY

--- a/pgactivity/queries/get_waiting_post_090200.sql
+++ b/pgactivity/queries/get_waiting_post_090200.sql
@@ -24,11 +24,11 @@ SELECT
  WHERE
       NOT pg_catalog.pg_locks.granted
   AND a.pid <> pg_backend_pid()
-  AND CASE WHEN %(min_duration)s = 0
+  AND CASE WHEN {min_duration} = 0
           THEN true
           ELSE extract(epoch from now() - {duration_column}) > %(min_duration)s
       END
-  AND CASE WHEN %(dbname_filter)s IS NULL THEN true
+  AND CASE WHEN {dbname_filter} IS NULL THEN true
       ELSE a.datname ~* %(dbname_filter)s
       END
 ORDER BY

--- a/pgactivity/queries/set_statement_timeout.sql
+++ b/pgactivity/queries/set_statement_timeout.sql
@@ -1,1 +1,0 @@
-SET statement_timeout TO %(timeout)s

--- a/pgactivity/ui.py
+++ b/pgactivity/ui.py
@@ -21,7 +21,6 @@ def main(
     width: Optional[int] = None,
     wait_on_actions: Optional[float] = None,
 ) -> None:
-
     fs_blocksize = options.blocksize
 
     is_local = data.pg_is_local() and data.pg_is_local_access()

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -452,7 +452,6 @@ def processes_rows(
     focused, pinned = processes.focused, processes.pinned
 
     for process in display_processes:
-
         if process.pid == focused:
             color_type = "cursor"
         elif process.pid in pinned:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ],
     extras_require={
         "dev": [
-            "black >= 21.12b0",
+            "black >= 23.1.0",
             "check-manifest",
             "codespell",
             "flake8",

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,13 @@ setup(
             "flake8",
             "mypy",
         ],
-        "testing": [
+        "psycopg2": [
             "psycopg2-binary >= 2.8",
+        ],
+        "psycopg": [
+            "psycopg[binary]",
+        ],
+        "testing": [
             "psycopg[binary]",
             "pytest",
             "pytest-postgresql >= 4.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,21 @@
 import logging
 import pathlib
 import threading
-from typing import Optional
+from typing import Any, List, Optional
 
 import psycopg
 from psycopg.conninfo import make_conninfo
 import psycopg.errors
 import pytest
 
+from pgactivity import pg
+
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
+
+
+def pytest_report_header(config: Any) -> List[str]:
+    return [f"psycopg: {pg.__version__}"]
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,16 @@
 [tox]
-envlist = check-manifest, lint, mypy, py{37,38,39,310}
+envlist = check-manifest, lint, mypy, py{37,38,39,310}-psycopg{2,3}
 skip_missing_interpreters = True
 
 [testenv]
 extras =
     testing
+    psycopg2: psycopg2
+    psycopg3: psycopg
 commands =
     pytest {toxinidir}/pgactivity {toxinidir}/tests {posargs:-vv}
+setenv =
+    psycopg2: _PGACTIVITY_USE_PSYCOPG2=1
 usedevelop = true
 
 [testenv:check-manifest]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 skip_install = True
 deps =
     codespell
-    black
+    black >= 23.1.0
     flake8
 commands =
     codespell {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ extras =
     testing
 commands =
     pytest {toxinidir}/pgactivity {toxinidir}/tests {posargs:-vv}
+usedevelop = true
 
 [testenv:check-manifest]
 skip_install = True


### PR DESCRIPTION
Alongside with psycopg2, we add support for psycopg 3 through a compatibility layer abstracting database operations.

A few changes in our queries are needed for them to work with psycopg 3, mostly about [server side binding](https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html#server-side-binding).