### PR TITLE
complement release how-to about changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc.
 
+* Add a change log file.
 * Use [codespell](https://github.com/codespell-project/codespell) to check
   misspellings.
 * Add Project-URLs core metadata for Python packaging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Misc.
 
-* Add a change log file.
+* Add a change log file and update the release how-to accordingly.
 * Use [codespell](https://github.com/codespell-project/codespell) to check
   misspellings.
 * Add Project-URLs core metadata for Python packaging.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,22 @@
 # Release HOW TO
 
-## Git
+## Preparatory changes
 
-* Write a new change log section, for instance from closed issues, merged pull
-  requests, or directly the git history (e.g. `git log $(git describe --tags
-  --abbrev=0).. --format=%s --reverse` to get commits from the previous tag)
-* Bump version in `pgactivity/__init__.py`, rebuild the man page
-* Commit these changes on the `master` branch
-* Create an annotated (and possibly signed) tag, as
-  `git tag -a [-s] -m 'pg_activity 1.6.0' v1.6.0`
-* Push with `--follow-tags`
+* Review the **Unreleased** section, if any, in `CHANGELOG.md` possibly adding
+  any missing item from closed issues, merged pull requests, or directly the git
+  history[^git-changes],
+* Rename the **Unreleased** section according to the version to be released,
+  with a date,
+* Bump the version in `pgactivity/__init__.py`,
+* Rebuild the man page, and,
+* Commit these changes (either on a dedicated branch, before submitting a pull
+  request or directly on the `master` branch).
+* Then, when changes landed in the `master` branch, create an annotated (and
+  possibly signed) tag, as `git tag -a [-s] -m 'pg_activity 1.6.0' v1.6.0`, and,
+* Push with `--follow-tags`.
+
+[^git-changes]: Use `git log $(git describe --tags --abbrev=0).. --format=%s
+  --reverse` to get commits from the previous tag.
 
 ## PyPI package
 


### PR DESCRIPTION
In #337, following #338, I added an `**Unreleased**` section in `CHANGELOG.md` following recommendations from https://keepachangelog.com/en/1.0.0/. So I am here adjusting the release how to explaining how to proceed about this.