### PR TITLE
Require blessed >= 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   misspellings.
 * Add Project-URLs core metadata for Python packaging.
 * Install the project in *develop* mode in Tox test environment.
+* Require blessed >= 1.15.0, as earlier versions are not compatible with Python
+  3.7.
 
 ## pg\_activity 3.0.2  - 2023-01-17
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "attrs >= 17, !=21.1",
-        "blessed",
+        "blessed >= 1.15.0",
         "humanize >= 2.6.0",
         "psutil >= 2.0.0",
     ],


### PR DESCRIPTION
cc @blogh about the issue we discussed offline:
```
$ pip install blessed==1.14.2
$ pg_activity
Traceback (most recent call last):
  File "/usr/lib/python3.9/sre_parse.py", line 1039, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\d'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/denis/src/pg_activity/.venv/bin/pg_activity", line 33, in <module>
    sys.exit(load_entry_point('pg-activity', 'console_scripts', 'pg_activity')())
  File "/home/denis/src/pg_activity/pgactivity/cli.py", line 404, in main
    term = Terminal()
  File "/home/denis/src/pg_activity/.venv/lib/python3.9/site-packages/blessed/terminal.py", line 226, in __init__
    self.__init__capabilities()
  File "/home/denis/src/pg_activity/.venv/lib/python3.9/site-packages/blessed/terminal.py", line 243, in __init__capabilities
    self.caps[name] = Termcap.build(
  File "/home/denis/src/pg_activity/.venv/lib/python3.9/site-packages/blessed/sequences.py", line 134, in build
    pattern = re.sub(r'\d+', _numeric_regex, _outp)
  File "/usr/lib/python3.9/re.py", line 210, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/lib/python3.9/re.py", line 327, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/lib/python3.9/re.py", line 318, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/lib/python3.9/sre_parse.py", line 1042, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \d at position 0
```