### PR TITLE
Use an empty string as default connection_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## pg\_activity 3.1.1 - 2023-03-06
+
+### Fixed
+
+* Fix crash on startup with no "connection string" argument and the psycopg
+  backend #346.
+
 ## pg\_activity 3.1.0 - 2023-03-01
 
 ### Added

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -185,6 +185,7 @@ def get_parser() -> ArgumentParser:
             "'host=HOSTNAME port=PORT user=USER dbname=DBNAME'."
         ),
         nargs="?",
+        default="",
         metavar="connection string",
     )
     # -h / --host


### PR DESCRIPTION
Otherwise, it defaults to None, which is not handled by psycopg 3+ (in contrast with psycopg2).

Closes #346 