### PR TITLE
Add compatibility with old humanize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 * Fall back to a permissive-but-hopefully-more-robust loader for character type
   values if client encoding is really `ascii`, when using the psycopg backend.
 
+### Misc.
+
+* Add compatibility with old humanize (>= 0.5.1), to make packaging easier on
+  old platforms such as RHEL 8.
+
 ## pg\_activity 3.1.1 - 2023-03-06
 
 ### Fixed

--- a/pgactivity/utils.py
+++ b/pgactivity/utils.py
@@ -8,12 +8,29 @@ import humanize
 
 
 naturalsize = functools.partial(humanize.naturalsize, gnu=True, format="%.2f")
-naturaltimedelta = functools.partial(
-    humanize.precisedelta,
-    minimum_unit="minutes",
-    format="%.0f",
-    suppress=["months", "years"],
-)
+try:
+    precisedelta = humanize.precisedelta
+except AttributeError:  # humanize < 2.6
+
+    def naturaltimedelta(d: timedelta) -> str:
+        """Render a timedelta with seconds truncated.
+
+        >>> d = timedelta(days=5, seconds=15182, microseconds=129198)
+        >>> naturaltimedelta(d)
+        '5 days, 4:13:00'
+        >>> str(d)
+        '5 days, 4:13:02.129198'
+        """
+        d = timedelta(days=d.days, seconds=d.seconds // 60 * 60)
+        return str(d)
+
+else:
+    naturaltimedelta = functools.partial(
+        humanize.precisedelta,
+        minimum_unit="minutes",
+        format="%.0f",
+        suppress=["months", "years"],
+    )
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     install_requires=[
         "attrs >= 17, !=21.1",
         "blessed >= 1.15.0",
-        "humanize >= 2.6.0",
+        "humanize >= 0.5.1",
         "psutil >= 2.0.0",
     ],
     extras_require={


### PR DESCRIPTION
This mostly affects how the uptime time delta is rendered, i.e. instead of getting something like '5 days, 4 hours and 13 minutes', we get '5 days, 4:13:00' when humanize.precisedelta() is not available and our compatibility layer is used.

