### PR TITLE
Delimit header columns with a comma instead of a dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## UNRELEASED
+
+### Fixed
+
+* Replace the previous header column separator (`⋅`) by a comma to improve user
+  experience in situations where that character did not render well (#356,
+  #230).
+
 ## pg\_activity 3.2.0 - 2023-03-06
 
 ### Fixed

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -188,7 +188,7 @@ def header(
         return f"{term.bold_green(hbytes)} - {term.bold_green(counts)}"
 
     def render_columns(
-        columns: Sequence[List[str]], *, delimiter: str
+        columns: Sequence[List[str]], *, delimiter: str = f"{term.blue(',')} "
     ) -> Iterator[str]:
         column_widths = [
             max(len(column_row) for column_row in column) for column in columns
@@ -237,7 +237,7 @@ def header(
             [f"{render(total_size)} dbs size - {render(size_ev)} growth"],
             [f"{render(si.cache_hit_ratio_last_snap)} cache hit ratio"],
         ]
-        yield from render_columns(columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(columns)
 
         columns = [
             [f"  Sessions: {render(si.total)}/{render(si.max_connections)} total"],
@@ -247,7 +247,7 @@ def header(
             [f"{render(si.idle_in_transaction_aborted)} idle in txn abrt"],
             [f"{render(si.waiting)} waiting"],
         ]
-        yield from render_columns(columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(columns)
 
         if si.temporary_file is not None:
             temp_files = si.temporary_file.temp_files
@@ -264,7 +264,7 @@ def header(
             [f"{render(temp_files)} temp files"],
             [f"{render(temp_size)} temp size"],
         ]
-        yield from render_columns(columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(columns)
     if ui.show_worker_info_in_header:
         columns = [
             [
@@ -277,7 +277,7 @@ def header(
                 f"{render(si.parallel_workers)}/{render(si.max_parallel_workers)} parallel workers"
             ],
         ]
-        yield from render_columns(columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(columns)
 
         columns = [
             [
@@ -289,7 +289,7 @@ def header(
                 f"{render(si.replication_slots)}/{render(si.max_replication_slots)} repl. slots"
             ],
         ]
-        yield from render_columns(columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(columns)
 
     # System information, only available in "local" mode.
     if system_info is not None and ui.show_system_info_in_header:
@@ -305,7 +305,7 @@ def header(
             [f"{render(used)} ({render(system_info.memory.pct_used)}) used"],
             [f"{render(bc)} ({render(system_info.memory.pct_bc)}) buff+cached"],
         ]
-        yield from render_columns(system_columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(system_columns)
 
         used, free, total = (
             utils.naturalsize(system_info.swap.used),
@@ -317,7 +317,7 @@ def header(
             [f"{render(free)} ({render(system_info.swap.pct_free)}) free"],
             [f"{render(used)} ({render(system_info.swap.pct_used)}) used"],
         ]
-        yield from render_columns(system_columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(system_columns)
 
         iops = f"{system_info.max_iops}/s"
         system_columns = [
@@ -325,7 +325,7 @@ def header(
             [f"{render(system_info.io_read)} read"],
             [f"{render(system_info.io_write)} write"],
         ]
-        yield from render_columns(system_columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(system_columns)
 
         load = system_info.load
         system_columns = [
@@ -333,7 +333,7 @@ def header(
                 f"  Load average: {render(load.avg1)} {render(load.avg5)} {render(load.avg15)}"
             ],
         ]
-        yield from render_columns(system_columns, delimiter=f" {term.bold_blue('⋅')} ")
+        yield from render_columns(system_columns)
 
 
 @limit

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -170,14 +170,14 @@ No activity, first screen followed by help screen:
 
 >>> run_ui(options, ["s", "o", "i", "h", "z", "q"])  # doctest: +ELLIPSIS
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s - Duration mode: query
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
- * Mem.: 8B total ⋅ 2B (25.00%) free ⋅ 2B (25.00%) used ⋅ 4B (50.00%) buff+cached
-   Swap: 2B total ⋅ 1B (50.00%) free ⋅ 1B (50.00%) used
-   IO: 300/s max iops ⋅ 200B/s - 100/s read ⋅ 300B/s - 200/s write
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
+ * Mem.: 8B total, 2B (25.00%) free, 2B (25.00%) used, 4B (50.00%) buff+cached
+   Swap: 2B total, 1B (50.00%) free, 1B (50.00%) used
+   IO: 300/s max iops, 200B/s - 100/s read, 300B/s - 200/s write
    Load average: 1 5 15
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT IOW              state Query
@@ -197,11 +197,11 @@ PID    DATABASE                     USER           CLIENT IOW              state
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key 's' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s - Duration mode: query
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT IOW              state Query
 <BLANKLINE>
@@ -224,9 +224,9 @@ PID    DATABASE                     USER           CLIENT IOW              state
 <BLANKLINE>
 ------------------------------------------------------------------------------------------- sending key 'o' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s - Duration mode: query
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT IOW              state Query
 <BLANKLINE>
@@ -345,11 +345,11 @@ Force non-local mode with the same mock data (and reset the term size)
 
 >>> run_ui(options, ["h","z","q"])  # doctest: +ELLIPSIS
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s - Duration mode: query
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT             state Query
 <BLANKLINE>
@@ -392,11 +392,11 @@ Mode
 Press any key to exit.
 ------------------------------------------------------------------------------------------- sending key 'z' --------------------------------------------------------------------------------------------
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s - Duration mode: query
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
                                 RUNNING QUERIES
 PID    DATABASE                     USER           CLIENT             state Query
 <BLANKLINE>

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -123,11 +123,11 @@ Remote host:
 ...        system_info=None, pg_version="PostgreSQL 9.6",
 ...        width=200)
 PostgreSQL 9.6 - server - pgadm@server.prod.tld:5433/app - Ref.: 10s - Duration mode: backend
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
 
 Local host, with privileged access:
 
@@ -143,14 +143,14 @@ Local host, with privileged access:
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)
 PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mode: backend
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
- * Mem.: 8B total ⋅ 2B (25.00%) free ⋅ 2B (25.00%) used ⋅ 4B (50.00%) buff+cached
-   Swap: 2B total ⋅ 1B (50.00%) free ⋅ 1B (50.00%) used
-   IO: 300/s max iops ⋅ 200B/s - 100/s read ⋅ 300B/s - 200/s write
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
+ * Mem.: 8B total, 2B (25.00%) free, 2B (25.00%) used, 4B (50.00%) buff+cached
+   Swap: 2B total, 1B (50.00%) free, 1B (50.00%) used
+   IO: 300/s max iops, 200B/s - 100/s read, 300B/s - 200/s write
    Load average: 1 5 15
 
 >>> ui.toggle_system_info_in_header()
@@ -158,11 +158,11 @@ PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mo
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)
 PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mode: backend
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
 
 >>> ui = UI.make(refresh_time=10, duration_mode=DurationMode.query)
 >>> ui.toggle_system_info_in_header()
@@ -171,9 +171,9 @@ PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mo
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)
 PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mode: query
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
 
 >>> ui = UI.make(refresh_time=2, min_duration=1.2, duration_mode=DurationMode.transaction)
 >>> ui.toggle_system_info_in_header()
@@ -196,9 +196,9 @@ PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 2s - Duration mod
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)
 PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 2s - Duration mode: transaction - Min. duration: 1.2s
- * Mem.: 0B total ⋅ 0B (-) free ⋅ 0B (-) used ⋅ 0B (-) buff+cached
-   Swap: 0B total ⋅ 0B (-) free ⋅ 0B (-) used
-   IO: 0/s max iops ⋅ 0B/s - 0/s read ⋅ 0B/s - 0/s write
+ * Mem.: 0B total, 0B (-) free, 0B (-) used, 0B (-) buff+cached
+   Swap: 0B total, 0B (-) free, 0B (-) used
+   IO: 0/s max iops, 0B/s - 0/s read, 0B/s - 0/s write
    Load average: 0 0 0
 
 Tests for processes_rows()
@@ -506,14 +506,14 @@ Tests for screen()
 ...     width=150,
 ... )
 PostgreSQL 13 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mode: backend - Min. duration: 1s
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s growth ⋅ 90.12% cache hit ratio
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn abrt ⋅ 3 waiting
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples returned/s ⋅ 5 temp files ⋅ 11.50M temp size
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal receivers ⋅ 10/10 repl. slots
- * Mem.: 8B total ⋅ 2B (25.00%) free ⋅ 2B (25.00%) used ⋅ 4B (50.00%) buff+cached
-   Swap: 2B total ⋅ 1B (50.00%) free ⋅ 1B (50.00%) used
-   IO: 300/s max iops ⋅ 200B/s - 100/s read ⋅ 300B/s - 200/s write
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s growth, 90.12% cache hit ratio
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt, 3 waiting
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
+ * Mem.: 8B total, 2B (25.00%) free, 2B (25.00%) used, 4B (50.00%) buff+cached
+   Swap: 2B total, 1B (50.00%) free, 1B (50.00%) used
+   IO: 300/s max iops, 200B/s - 100/s read, 300B/s - 200/s write
    Load average: 1 5 15
                                 RUNNING QUERIES
 PID    DATABASE         CPU%   MEM%             state Query
@@ -542,14 +542,14 @@ F1/1 Running queries    F2/2 Waiting queries    F3/3 Blocking queries   Space Pa
 ...     message=f"Process {processes3[-1].pid} killed",
 ... )
 PostgreSQL 13 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration
- * Global: 132 days, 3 hours and 21 minutes uptime ⋅ 19.53M dbs size - 1.00K/s
-   Sessions: 6/100 total ⋅ 1 active ⋅ 1 idle ⋅ 10 idle in txn ⋅ 0 idle in txn
-   Activity: 15 tps ⋅ 10 insert/s ⋅ 20 update/s ⋅ 30 delete/s ⋅ 40 tuples
- * Worker processes: 3/8 total ⋅ 1/8 logical workers ⋅ 2/8 parallel workers
-   Other processes & info: 3/3 autovacuum workers ⋅ 1/10 wal senders ⋅ 0 wal
- * Mem.: 8B total ⋅ 2B (25.00%) free ⋅ 2B (25.00%) used ⋅ 4B (50.00%)
-   Swap: 2B total ⋅ 1B (50.00%) free ⋅ 1B (50.00%) used
-   IO: 300/s max iops ⋅ 200B/s - 100/s read ⋅ 300B/s - 200/s write
+ * Global: 132 days, 3 hours and 21 minutes uptime, 19.53M dbs size - 1.00K/s
+   Sessions: 6/100 total, 1 active, 1 idle, 10 idle in txn, 0 idle in txn abrt,
+   Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples
+ * Worker processes: 3/8 total, 1/8 logical workers, 2/8 parallel workers
+   Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal
+ * Mem.: 8B total, 2B (25.00%) free, 2B (25.00%) used, 4B (50.00%) buff+cached
+   Swap: 2B total, 1B (50.00%) free, 1B (50.00%) used
+   IO: 300/s max iops, 200B/s - 100/s read, 300B/s - 200/s write
    Load average: 1 5 15
                                 RUNNING QUERIES
 PID    DATABASE         CPU%   MEM%             state Query


### PR DESCRIPTION
The character we were previously using, U+22C5 DOT OPERATOR, is apparently not rendering well for everybody. Let's use a plain ASCII character instead.

Fix #356
Fix #230