### PR TITLE
Use isort to automatically sort imports

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
         run: pip install tox
       - name: Check manifest
         run: tox -e check-manifest
-      - name: Lint (black & flake8)
+      - name: Lint
         run: tox -e lint
       - name: Mypy
         run: tox -e mypy

--- a/pgactivity/activities.py
+++ b/pgactivity/activities.py
@@ -9,15 +9,15 @@ import psutil
 
 from .types import (
     BlockingProcess,
-    WaitingProcess,
     IOCounter,
     LoadAverage,
     LocalRunningProcess,
     MemoryInfo,
     RunningProcess,
     SortKey,
-    SystemProcess,
     SwapInfo,
+    SystemProcess,
+    WaitingProcess,
 )
 
 

--- a/pgactivity/colors.py
+++ b/pgactivity/colors.py
@@ -1,6 +1,5 @@
 from . import utils
 
-
 FIELD_BY_MODE = {
     "pid": {"default": "cyan", "cursor": "cyan_reverse", "yellow": "yellow_bold"},
     "database": {

--- a/pgactivity/compat.py
+++ b/pgactivity/compat.py
@@ -3,7 +3,6 @@ from typing import Any, Dict
 import attr
 import blessed
 
-
 ATTR_VERSION = tuple(int(x) for x in attr.__version__.split(".", 2)[:2])
 BLESSED_VERSION = tuple(int(x) for x in blessed.__version__.split(".", 2)[:2])
 

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -8,21 +8,20 @@ from typing import Dict, List, Optional
 import attr
 import psutil
 
-from . import queries, pg
-from .pg import sql, Connection
+from . import pg, queries
+from .pg import Connection, sql
 from .types import (
+    NO_FILTER,
     BlockingProcess,
     FailedQueriesInfo,
     Filters,
-    WaitingProcess,
     Pct,
     RunningProcess,
     ServerInformation,
     TempFileInfo,
-    NO_FILTER,
+    WaitingProcess,
 )
 from .utils import clean_str
-
 
 logger = logging.getLogger("pgactivity")
 

--- a/pgactivity/pg.py
+++ b/pgactivity/pg.py
@@ -22,18 +22,16 @@ try:
     from psycopg import sql as sql
     from psycopg._encodings import pg2pyenc
     from psycopg.adapt import Buffer, Loader
-    from psycopg.conninfo import make_conninfo, conninfo_to_dict
+    from psycopg.conninfo import conninfo_to_dict, make_conninfo
+    from psycopg.errors import FeatureNotSupported as FeatureNotSupported
+    from psycopg.errors import InsufficientPrivilege as InsufficientPrivilege
+    from psycopg.errors import InterfaceError as InterfaceError
+    from psycopg.errors import InvalidPassword as InvalidPassword
+    from psycopg.errors import NotSupportedError
+    from psycopg.errors import OperationalError as OperationalError
+    from psycopg.errors import ProgrammingError as ProgrammingError
+    from psycopg.errors import QueryCanceled as QueryCanceled
     from psycopg.rows import dict_row
-    from psycopg.errors import (
-        NotSupportedError,
-        FeatureNotSupported as FeatureNotSupported,
-        InterfaceError as InterfaceError,
-        InvalidPassword as InvalidPassword,
-        InsufficientPrivilege as InsufficientPrivilege,
-        OperationalError as OperationalError,
-        ProgrammingError as ProgrammingError,
-        QueryCanceled as QueryCanceled,
-    )
 
     __version__ = psycopg.__version__
 
@@ -187,19 +185,20 @@ except ImportError:
 
     import psycopg2
     import psycopg2.extensions
-    from psycopg2.extras import DictCursor
     from psycopg2 import sql as sql  # type: ignore[no-redef]
-    from psycopg2.errors import (  # type: ignore[no-redef]
-        FeatureNotSupported as FeatureNotSupported,
-        InterfaceError as InterfaceError,
-        InvalidPassword as InvalidPassword,
-        InsufficientPrivilege as InsufficientPrivilege,
-        OperationalError as OperationalError,
-        ProgrammingError as ProgrammingError,
-        QueryCanceled as QueryCanceled,
-    )
 
+    # isort: off
+    from psycopg2.errors import FeatureNotSupported as FeatureNotSupported  # type: ignore[no-redef]
+    from psycopg2.errors import InsufficientPrivilege as InsufficientPrivilege  # type: ignore[no-redef]
+    from psycopg2.errors import InterfaceError as InterfaceError  # type: ignore[no-redef]
+    from psycopg2.errors import InvalidPassword as InvalidPassword  # type: ignore[no-redef]
+    from psycopg2.errors import OperationalError as OperationalError  # type: ignore[no-redef]
+    from psycopg2.errors import ProgrammingError as ProgrammingError  # type: ignore[no-redef]
+    from psycopg2.errors import QueryCanceled as QueryCanceled  # type: ignore[no-redef]
+
+    # isort: on
     from psycopg2.extensions import connection as Connection  # type: ignore[no-redef]
+    from psycopg2.extras import DictCursor
 
     __version__ = psycopg2.__version__
 

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -11,19 +11,19 @@ from typing import (
     Mapping,
     MutableSet,
     Optional,
-    overload,
     Sequence,
     Tuple,
     Type,
     TypeVar,
     Union,
+    overload,
 )
 
 import attr
 import psutil
 from attr import validators
 
-from . import compat, colors, utils, pg
+from . import colors, compat, pg, utils
 
 
 class Pct(float):

--- a/pgactivity/utils.py
+++ b/pgactivity/utils.py
@@ -1,11 +1,10 @@
 import functools
 import re
 from datetime import datetime, timedelta
-from typing import Any, IO, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import IO, Any, Iterable, List, Mapping, Optional, Tuple, Union
 
 import attr
 import humanize
-
 
 naturalsize = functools.partial(humanize.naturalsize, gnu=True, format="%.2f")
 try:

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -2,33 +2,26 @@ import functools
 import inspect
 import itertools
 from textwrap import TextWrapper, dedent
-from typing import (
-    Any,
-    Callable,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Sequence,
-)
+from typing import Any, Callable, Iterable, Iterator, List, Optional, Sequence, Tuple
 
 from blessed import Terminal
 
+from . import colors, utils
+from .activities import sorted as sorted_processes
 from .compat import link
+from .keys import BINDINGS, EXIT_KEY
+from .keys import HELP as HELP_KEY
 from .keys import (
-    BINDINGS,
-    EXIT_KEY,
-    HELP as HELP_KEY,
     KEYS_BY_QUERYMODE,
-    Key,
     MODES,
     PAUSE_KEY,
     PROCESS_CANCEL,
     PROCESS_KILL,
     PROCESS_PIN,
+    Key,
 )
 from .types import (
+    UI,
     ActivityStats,
     Column,
     Host,
@@ -37,10 +30,7 @@ from .types import (
     SelectableProcesses,
     ServerInformation,
     SystemInfo,
-    UI,
 )
-from . import colors, utils
-from .activities import sorted as sorted_processes
 
 
 class line_counter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ exclude = '''
   )/
 )
 '''
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             "check-manifest",
             "codespell",
             "flake8",
+            "isort",
             "mypy",
         ],
         "psycopg2": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,10 @@ import threading
 from typing import Any, List, Optional
 
 import psycopg
-from psycopg.conninfo import make_conninfo
-from psycopg import sql
 import psycopg.errors
 import pytest
+from psycopg import sql
+from psycopg.conninfo import make_conninfo
 
 from pgactivity import pg
 

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -11,8 +11,8 @@ from pgactivity.types import (
     LoadAverage,
     MemoryInfo,
     RunningProcess,
-    SystemProcess,
     SwapInfo,
+    SystemProcess,
 )
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,8 +2,8 @@ import time
 from typing import Optional
 
 import attr
-import pytest
 import psycopg
+import pytest
 from psycopg.errors import WrongObjectType
 
 from pgactivity import types

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,7 +2,7 @@ import pytest
 from blessed import Terminal
 
 from pgactivity import views
-from pgactivity.types import Flag, QueryMode, SortKey, UI
+from pgactivity.types import UI, Flag, QueryMode, SortKey
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,12 @@ deps =
     codespell
     black >= 23.1.0
     flake8
+    isort
 commands =
     codespell {toxinidir}
     black --check --diff {toxinidir}
     flake8 {toxinidir}
+    isort --check --diff {toxinidir}
 
 [testenv:mypy]
 deps =


### PR DESCRIPTION
https://pycqa.github.io/isort/ is nice to get imports ordered automatically; so let's use it and configure it so that it plays nicely with black.

Changes are mostly the result of running isort from the top-level directory. Only part of changes in the 'pg' module are handled by hand, typically the part between 'isort: off'/'isort: on' because isort otherwise messes up 'type: ignore' comments.