### PR TITLE
Upgrade Python syntax thanks to pyupgrade

### DIFF
--- a/pgactivity/compat.py
+++ b/pgactivity/compat.py
@@ -9,7 +9,7 @@ BLESSED_VERSION = tuple(int(x) for x in blessed.__version__.split(".", 2)[:2])
 if ATTR_VERSION < (18, 1):
 
     def fields_dict(cls: Any) -> Dict[str, Any]:
-        return dict(((a.name, a) for a in cls.__attrs_attrs__))
+        return {a.name: a for a in cls.__attrs_attrs__}
 
 else:
     fields_dict = attr.fields_dict

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -143,7 +143,7 @@ class Data:
 
         pid_file = f"{ret['data_directory']}/postmaster.pid"
         try:
-            with open(pid_file, "r") as fd:
+            with open(pid_file) as fd:
                 pid = fd.readline().strip()
         except OSError as e:
             logger.info(

--- a/pgactivity/utils.py
+++ b/pgactivity/utils.py
@@ -153,9 +153,9 @@ def format_duration(duration: Optional[float]) -> Tuple[str, str]:
             color = "time_red"
         duration_d = timedelta(seconds=float(duration))
         mic = "%.6d" % duration_d.microseconds
-        ctime = "%s:%s.%s" % (
-            str((duration_d.seconds // 60)).zfill(2),
-            str((duration_d.seconds % 60)).zfill(2),
+        ctime = "{}:{}.{}".format(
+            str(duration_d.seconds // 60).zfill(2),
+            str(duration_d.seconds % 60).zfill(2),
             mic[:2],
         )
     else:

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -136,8 +136,7 @@ def help(term: Terminal, version: str, is_local: bool) -> Iterable[str]:
             yield f"{term.bright_cyan}{key_name.rjust(10)}{term.normal}: {key.description}"
 
     footer = "Press any key to exit."
-    for line in intro.splitlines():
-        yield line
+    yield from intro.splitlines()
     yield ""
 
     bindings = BINDINGS
@@ -468,8 +467,7 @@ def processes_rows(
 
             cell(query_value, ui.column("query"))
 
-        for line in (" ".join(text) + term.normal).splitlines():
-            yield line
+        yield from (" ".join(text) + term.normal).splitlines()
 
 
 def footer_message(term: Terminal, message: str, width: Optional[int] = None) -> None:


### PR DESCRIPTION
Result from running 'pyupgrade --py37-plus'.

Note: we don't run this by default in tox or CI because there's no way to configure this tool; so this is just a one-shot.