### PR TITLE
Drop explicit Python versions from tox environment name

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = check-manifest, lint, mypy, py{37,38,39,310}-psycopg{2,3}
+envlist = check-manifest, lint, mypy, py-psycopg{2,3}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
It's not needed as the simple 'py-' prefix is enough to be able to pick, e.g., python 3.10 with 'tox -e py310-psycopg2'.