### PR TITLE
Fix a type error upon reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## UNRELEASED
+
+### Fixed
+
+* Fix a crash when trying to reconnect.
+
 ## pg\_activity 3.3.0 - 2023-03-22
 
 ### Fixed

--- a/pgactivity/pg.py
+++ b/pgactivity/pg.py
@@ -49,7 +49,7 @@ try:
                 data = bytes(data)
             return data.decode(errors="replace")
 
-    def connect(dsn: str, **kwargs: Any) -> Connection:
+    def connect(dsn: str = "", **kwargs: Any) -> Connection:
         if "PGCLIENTENCODING" not in os.environ:
             # Set client_encoding to 'auto', if not set by the user.
             # This is (more or less) what's done by psql.
@@ -202,7 +202,7 @@ except ImportError:
 
     __version__ = psycopg2.__version__
 
-    def connect(dsn: str, **kwargs: Any) -> Connection:
+    def connect(dsn: str = "", **kwargs: Any) -> Connection:
         try:
             kwargs.setdefault("database", kwargs.pop("dbname"))
         except KeyError:


### PR DESCRIPTION
Resolves the following error, that occurs if the connection is lost (e.g. server shutdown):

    server closed the connection unexpectedly
            This probably means the server terminated abnormally
            before or while processing the request.

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File ".../src/pg_activity/.venv/bin/pg_activity", line 8, in <module>
        sys.exit(main())
      File ".../src/pg_activity/pgactivity/cli.py", line 416, in main
        newdataobj = dataobj.try_reconnect()
      File ".../src/pg_activity/pgactivity/data.py", line 122, in try_reconnect
        pg_conn = pg.connect(**self.dsn_parameters)
    TypeError: connect() missing 1 required positional argument: 'dsn'

The 'dsn' argument of pg.connect() was incorrectly required.