### PR TITLE
Preserve the 'inet' type of client_addr column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## UNRELEASED
 
+### Added
+
+* Improve rendering of the `client` column by possibly abbreviating IP
+  addresses.
+
 ### Fixed
 
 * Fix a crash when trying to reconnect.

--- a/pgactivity/activities.py
+++ b/pgactivity/activities.py
@@ -1,6 +1,7 @@
 import builtins
 import os
 import time
+from ipaddress import IPv4Interface, ip_address
 from typing import Dict, List, Optional, Sequence, Tuple, TypeVar
 from warnings import catch_warnings, simplefilter
 
@@ -156,7 +157,7 @@ def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T
     ...         application_name="pgbench",
     ...         database="pgbench",
     ...         user="postgres",
-    ...         client="local",
+    ...         client=ip_address("127.0.0.2"),
     ...         cpu=0.1,
     ...         mem=0.993_254_939_413_836,
     ...         read=0.1,
@@ -175,7 +176,7 @@ def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T
     ...         application_name="pgbench",
     ...         database="pgbench",
     ...         user="postgres",
-    ...         client="local",
+    ...         client=IPv4Interface("192.0.2.5/24"),
     ...         cpu=0.1,
     ...         mem=0.994_254_939_413_836,
     ...         read=0.1,
@@ -194,7 +195,7 @@ def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T
     ...         application_name="pgbench",
     ...         database="pgbench",
     ...         user="postgres",
-    ...         client="local",
+    ...         client=ip_address("2001:db8::"),
     ...         cpu=0.2,
     ...         mem=1.024_758_418_061_11,
     ...         read=0.2,
@@ -230,7 +231,7 @@ def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T
     ...         application_name="pgbench",
     ...         database="pgbench",
     ...         user="postgres",
-    ...         client="local",
+    ...         client=ip_address("192.168.1.2"),
     ...         cpu=0.1,
     ...         mem=0.993_254_939_413_836,
     ...         read=0.1,
@@ -249,7 +250,7 @@ def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T
     ...         application_name="pgbench",
     ...         database="pgbench",
     ...         user="postgres",
-    ...         client="local",
+    ...         client=ip_address("0000:0000:0000:0000:0000:0abc:0007:0def"),
     ...         cpu=0.1,
     ...         mem=0.994_254_939_413_836,
     ...         read=0.1,
@@ -268,7 +269,7 @@ def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T
     ...         application_name="pgbench",
     ...         database="pgbench",
     ...         user="postgres",
-    ...         client="local",
+    ...         client=None,
     ...         cpu=0.2,
     ...         mem=1.024_758_418_061_11,
     ...         read=0.2,

--- a/pgactivity/queries/get_blocking_oldest.sql
+++ b/pgactivity/queries/get_blocking_oldest.sql
@@ -32,10 +32,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             NULL AS state,
@@ -65,10 +62,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             NULL AS state,
@@ -98,10 +92,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             NULL AS state,

--- a/pgactivity/queries/get_blocking_post_090200.sql
+++ b/pgactivity/queries/get_blocking_post_090200.sql
@@ -27,10 +27,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,
@@ -60,10 +57,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,
@@ -93,10 +87,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,

--- a/pgactivity/queries/get_blocking_post_090600.sql
+++ b/pgactivity/queries/get_blocking_post_090600.sql
@@ -25,10 +25,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,
@@ -58,10 +55,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,
@@ -91,10 +85,7 @@ SELECT
             pg_stat_activity.datname,
             pg_stat_activity.datid,
             pg_stat_activity.usename,
-            CASE WHEN pg_stat_activity.client_addr IS NULL
-                THEN 'local'
-                ELSE pg_stat_activity.client_addr::TEXT
-            END AS client,
+            pg_stat_activity.client_addr AS client,
             blocking.locktype,
             EXTRACT(epoch FROM (NOW() - pg_stat_activity.{duration_column})) AS duration,
             pg_stat_activity.state as state,

--- a/pgactivity/queries/get_pg_activity_oldest.sql
+++ b/pgactivity/queries/get_pg_activity_oldest.sql
@@ -3,10 +3,7 @@ SELECT
       a.procpid AS pid,
       '<unknown>' AS application_name,
       a.datname AS database,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       a.waiting AS wait,
       a.usename AS user,

--- a/pgactivity/queries/get_pg_activity_post_090200.sql
+++ b/pgactivity/queries/get_pg_activity_post_090200.sql
@@ -5,10 +5,7 @@ SELECT
       a.pid AS pid,
       a.application_name AS application_name,
       a.datname AS database,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       a.waiting AS wait,
       a.usename AS user,

--- a/pgactivity/queries/get_pg_activity_post_090600.sql
+++ b/pgactivity/queries/get_pg_activity_post_090600.sql
@@ -5,10 +5,7 @@ SELECT
       a.pid AS pid,
       a.application_name AS application_name,
       a.datname AS database,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       a.wait_event AS wait,
       a.usename AS user,

--- a/pgactivity/queries/get_pg_activity_post_100000.sql
+++ b/pgactivity/queries/get_pg_activity_post_100000.sql
@@ -5,10 +5,7 @@ SELECT
       a.pid AS pid,
       a.application_name AS application_name,
       a.datname AS database,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       a.wait_event as wait,
       a.usename AS user,

--- a/pgactivity/queries/get_pg_activity_post_110000.sql
+++ b/pgactivity/queries/get_pg_activity_post_110000.sql
@@ -4,10 +4,7 @@ SELECT
       a.pid AS pid,
       a.application_name AS application_name,
       a.datname AS database,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       a.wait_event AS wait,
       a.usename AS user,

--- a/pgactivity/queries/get_pg_activity_post_130000.sql
+++ b/pgactivity/queries/get_pg_activity_post_130000.sql
@@ -4,10 +4,7 @@ SELECT
       a.pid AS pid,
       a.application_name AS application_name,
       a.datname AS database,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       EXTRACT(epoch FROM (NOW() - a.{duration_column})) AS duration,
       a.wait_event AS wait,
       a.usename AS user,

--- a/pgactivity/queries/get_waiting_oldest.sql
+++ b/pgactivity/queries/get_waiting_oldest.sql
@@ -4,10 +4,7 @@ SELECT
       '<unknown>' AS application_name,
       a.datname AS database,
       a.usename AS user,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       pg_locks.mode AS mode,
       pg_locks.locktype AS type,
       pg_locks.relation::regclass AS relation,

--- a/pgactivity/queries/get_waiting_post_090200.sql
+++ b/pgactivity/queries/get_waiting_post_090200.sql
@@ -7,10 +7,7 @@ SELECT
       a.application_name AS application_name,
       a.datname AS database,
       a.usename AS user,
-      CASE WHEN a.client_addr IS NULL
-          THEN 'local'
-          ELSE a.client_addr::TEXT
-      END AS client,
+      a.client_addr AS client,
       pg_locks.mode AS mode,
       pg_locks.locktype AS type,
       pg_locks.relation::regclass AS relation,

--- a/tests/data/local-processes-input.json
+++ b/tests/data/local-processes-input.json
@@ -3,7 +3,7 @@
     "new_processes": {
         "6221": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002731,
@@ -56,7 +56,7 @@
         },
         "6222": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003539,
@@ -109,7 +109,7 @@
         },
         "6223": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002385,
@@ -162,7 +162,7 @@
         },
         "6224": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.00302,
@@ -215,7 +215,7 @@
         },
         "6225": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002305,
@@ -268,7 +268,7 @@
         },
         "6226": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002623,
@@ -321,7 +321,7 @@
         },
         "6227": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002693,
@@ -374,7 +374,7 @@
         },
         "6228": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003339,
@@ -427,7 +427,7 @@
         },
         "6229": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003353,
@@ -480,7 +480,7 @@
         },
         "6230": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003495,
@@ -533,7 +533,7 @@
         },
         "6231": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003384,
@@ -586,7 +586,7 @@
         },
         "6232": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002212,
@@ -639,7 +639,7 @@
         },
         "6233": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002273,
@@ -692,7 +692,7 @@
         },
         "6234": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002408,
@@ -745,7 +745,7 @@
         },
         "6235": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002635,
@@ -798,7 +798,7 @@
         },
         "6237": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003559,
@@ -851,7 +851,7 @@
         },
         "6238": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003481,
@@ -904,7 +904,7 @@
         },
         "6239": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003428,
@@ -957,7 +957,7 @@
         },
         "6240": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002256,
@@ -1012,7 +1012,7 @@
     "processes": {
         "6221": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002794,
@@ -1065,7 +1065,7 @@
         },
         "6222": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003188,
@@ -1118,7 +1118,7 @@
         },
         "6223": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.00347,
@@ -1171,7 +1171,7 @@
         },
         "6224": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003245,
@@ -1224,7 +1224,7 @@
         },
         "6225": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003286,
@@ -1277,7 +1277,7 @@
         },
         "6226": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003431,
@@ -1330,7 +1330,7 @@
         },
         "6227": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002061,
@@ -1383,7 +1383,7 @@
         },
         "6228": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003475,
@@ -1436,7 +1436,7 @@
         },
         "6229": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003226,
@@ -1489,7 +1489,7 @@
         },
         "6230": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002711,
@@ -1542,7 +1542,7 @@
         },
         "6231": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.001462,
@@ -1595,7 +1595,7 @@
         },
         "6232": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003435,
@@ -1648,7 +1648,7 @@
         },
         "6233": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.00339,
@@ -1701,7 +1701,7 @@
         },
         "6234": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003179,
@@ -1754,7 +1754,7 @@
         },
         "6235": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003405,
@@ -1807,7 +1807,7 @@
         },
         "6236": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002822,
@@ -1860,7 +1860,7 @@
         },
         "6237": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.002788,
@@ -1913,7 +1913,7 @@
         },
         "6238": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003436,
@@ -1966,7 +1966,7 @@
         },
         "6239": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.00305,
@@ -2019,7 +2019,7 @@
         },
         "6240": {
             "application_name": "pgbench",
-            "client": "local",
+            "client": null,
             "cpu": null,
             "database": "pgbench",
             "duration": -0.003586,

--- a/tests/test_scroll.txt
+++ b/tests/test_scroll.txt
@@ -15,7 +15,7 @@ Tests scrolling in processes_rows()
 ...         application_name="pgbench",
 ...         database="pgbench",
 ...         user="postgres",
-...         client="local",
+...         client=None,
 ...         state="active",
 ...         query=f"SELECT {x}",
 ...         encoding=None,

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -437,7 +437,7 @@ change query mode then quit:
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 2s - Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -463,7 +463,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -489,7 +489,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 0.5s - Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -515,7 +515,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -541,7 +541,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -567,7 +567,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -593,7 +593,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -619,7 +619,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: query
                                      PAUSE
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -645,7 +645,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: query
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -671,7 +671,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -697,7 +697,7 @@ tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_s
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
@@ -749,7 +749,7 @@ DATABASE                     USER           CLIENT  RELATION             TYPE   
 PostgreSQL ... - test - postgres@127.0.0.1:.../tests - Ref.: 1s - Duration mode: transaction
                                 RUNNING QUERIES
 DATABASE                     USER           CLIENT             state Query
-tests                    postgres     127.0.0.1/32     idle in trans SELECT pg_sleep(0)
+tests                    postgres        127.0.0.1     idle in trans SELECT pg_sleep(0)
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -1,3 +1,4 @@
+>>> from ipaddress import ip_address, ip_interface
 >>> import attr
 >>> from blessed import Terminal
 >>> import os
@@ -210,7 +211,7 @@ Tests for processes_rows()
 ...         application_name="pgbench",
 ...         database="pgbench",
 ...         user="postgres",
-...         client="local",
+...         client=None,
 ...         cpu=0.1,
 ...         mem=0.993_254_939_413_836,
 ...         read=7,
@@ -229,7 +230,7 @@ Tests for processes_rows()
 ...         application_name="pgbench",
 ...         database="pgbench",
 ...         user="postgres",
-...         client="local",
+...         client=None,
 ...         cpu=0.2,
 ...         mem=1.024_758_418_061_11,
 ...         read=0.2,
@@ -248,7 +249,7 @@ Tests for processes_rows()
 ...         application_name="accounting",
 ...         database="business",
 ...         user="bob",
-...         client="local",
+...         client=None,
 ...         cpu=2.4,
 ...         mem=1.031_191_760_016_45,
 ...         read=9_876_543.21,
@@ -330,7 +331,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         application_name="pgbench",
 ...         database="pgbench",
 ...         user="postgres",
-...         client="1.2.3.4",
+...         client=ip_address("1.2.3.4"),
 ...         mode="ExclusiveLock",
 ...         type="transactionid",
 ...         relation="None",
@@ -345,7 +346,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         application_name="pgbench",
 ...         database="pgbench",
 ...         user="postgres",
-...         client="local",
+...         client=ip_interface("2001:4f8:3:ba:2e0:81ff:fe22:d1f1/128"),
 ...         mode="RowExclusiveLock",
 ...         type="tuple",
 ...         relation="ahah",
@@ -364,7 +365,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 >>> ui = UI.make(query_mode=QueryMode.blocking, flag=allflags)
 >>> processes_rows(term, ui, SelectableProcesses(processes2), 100, width=250)
 6239   pgbench                   pgbench         postgres          1.2.3.4      None    transactionid    ExclusiveLock  11:06.00      Client Read            active END;
-6228   pgbench                   pgbench         postgres            local      ahah            tuple RowExclusiveLock  0.000413      Client Read     idle in trans UPDATE pgbench_branches SET bbalance = bbalance + 1788 WHERE bid = 68;
+6228   pgbench                   pgbench         postgres 2001:4f8:3:ba:2e      ahah            tuple RowExclusiveLock  0.000413      Client Read     idle in trans UPDATE pgbench_branches SET bbalance = bbalance + 1788 WHERE bid = 68;
 
 >>> processes1b = [
 ...     RunningProcess(
@@ -372,7 +373,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         application_name="pgbench",
 ...         database="pgbench",
 ...         user="postgres",
-...         client="local",
+...         client=ip_interface("2001:db8::1/96"),
 ...         state="idle in transaction",
 ...         query="UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;",
 ...         encoding="UTF-8",
@@ -386,7 +387,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         application_name="none",
 ...         database="pgbench",
 ...         user="postgres",
-...         client="local",
+...         client=ip_interface("10.1.0.0/16"),
 ...         state="active",
 ...         query="UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;",
 ...         encoding="UTF-8",
@@ -400,7 +401,7 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 ...         application_name="accounting",
 ...         database="business",
 ...         user="bob",
-...         client="192.168.0.47",
+...         client=ip_address("192.168.0.47"),
 ...         state="active",
 ...         query="SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id) WHERE s.date > CURRENT_DATE - INTERVAL '4 weeks' GROUP BY product_id, p.name, p.price, p.cost HAVING sum(p.price * s.units) > 5000;",
 ...         encoding="UTF-8",
@@ -413,8 +414,8 @@ Terminal is too narrow given selected flags, we switch to wrap_noindent mode
 >>> all_but_local_flags = Flag.PID|Flag.DATABASE|Flag.APPNAME|Flag.USER|Flag.CLIENT|Flag.TIME|Flag.WAIT
 >>> ui = UI.make(query_mode=QueryMode.activities,flag=all_but_local_flags)
 >>> processes_rows(term, ui, SelectableProcesses(processes1b), 100, width=200)
-6239   pgbench                   pgbench         postgres            local  0.000000                N     idle in trans UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
-6228   pgbench                      none         postgres            local  0.000413                Y            active \_ UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
+6239   pgbench                   pgbench         postgres   2001:db8::1/96  0.000000                N     idle in trans UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
+6228   pgbench                      none         postgres      10.1.0.0/16  0.000413                Y            active \_ UPDATE pgbench_accounts SET abalance = abalance + 141 WHERE aid = 1932841;
 1234   business               accounting              bob     192.168.0.47  20:34.00             clog            active SELECT product_id, p.name FROM products p LEFT JOIN sales s USING (product_id)
 
 Tests for footer_*()


### PR DESCRIPTION
Instead of casting the client_addr to TEXT in PostgreSQL we keep the inet value which will be handled fine by psycopg. This brings us a nicer representation of some values, e.g. from 192.168.1.5/32 previously to 192.168.1.5. This will also help for IPv6 addresses which, if shortened that way, might fit better within the max width of the "client" column.

This is an alternative solution towards fixing #365, but not a complete solution as the column width is still limited to 16.