### PR TITLE
Drop now unneeded mypy ignore for 'humanize'

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,9 +6,6 @@ strict = true
 [mypy-setup]
 ignore_errors = True
 
-[mypy-humanize.*]
-ignore_missing_imports = True
-
 [mypy-psutil.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
The humanize library has type hints since version 4.2.0.