### PR TITLE
Add new --queries-only flag for best viewport usage and performance

### DIFF
--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -507,6 +507,11 @@ required by another session. It shows following information:
 .Vb 1
 \&        Display workers process information in header.
 .Ve
+.IP "\fB\-\-no\-inst\-info\fR" 2
+.IX Item "--queries-only"
+.Vb 1
+\&        Show only PID, user, time, waiting and query columns without any information headers.
+.Ve
 .IP "\fB\-\-refresh\fR" 2
 .IX Item "--refresh"
 .Vb 1

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -3,7 +3,7 @@ import os
 import socket
 import sys
 import time
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from io import StringIO
 from typing import Optional
 
@@ -347,6 +347,14 @@ def get_parser() -> ArgumentParser:
         help="Display workers process information in header.",
         default=True,
     )
+    # --queries-only
+    group.add_argument(
+        "--queries-only",
+        dest="queries_only",
+        action="store_true",
+        help="Show only PID, user, time, waiting and query columns without any information headers.",
+        default=False,
+    )
     # --refresh
     group.add_argument(
         "--refresh",
@@ -359,6 +367,22 @@ def get_parser() -> ArgumentParser:
     )
 
     return parser
+
+
+def set_queries_only_flags(args: Namespace):
+    args.show_instance_info_in_header = False
+    args.show_system_info_in_header = False
+    args.show_worker_info_in_header = False
+    args.nodbsize = True
+    args.notempfiles = True
+    args.nowalreceiver = True
+    args.nodb = True
+    args.noclient = True
+    args.nocpu = True
+    args.nomem = True
+    args.noread = True
+    args.nowrite = True
+    args.noappname = True
 
 
 def exit(msg: str) -> None:
@@ -385,6 +409,8 @@ def main() -> None:
         parser.error(str(e))
     if args.rds:
         args.notempfile = True
+    if args.queries_only:
+        set_queries_only_flags(args)
 
     try:
         cfg = Configuration.lookup()


### PR DESCRIPTION
As there are quite many viewport customization flags, it's currently quite tedious to set things for most compact viewport usage, when on some terminal withing a terminal, as it quite often is on the clouds.

Other effect is that in this mode we're a bit lighter on the monitored DB, skipping some queries.