### PR TITLE
Catch connection error from the CLI entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * The *rollback ration* is now displayed in the "global" header (#385).
 
+### Fixed
+
+* At startup, do not show a traceback upon failure to connect to PostgreSQL.
+
 ### Misc
 
 * Document how to *hack* on pg\_activity in the `README`.

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -391,12 +391,15 @@ def main() -> None:
     except ConfigurationError as e:
         parser.error(str(e))
 
-    dataobj = data.pg_connect(
-        args,
-        args.connection_string,
-        min_duration=args.minduration,
-        filters=filters,
-    )
+    try:
+        dataobj = data.pg_connect(
+            args,
+            args.connection_string,
+            min_duration=args.minduration,
+            filters=filters,
+        )
+    except OperationalError as e:
+        parser.exit(status=1, message=f"could not connect to PostgreSQL: {e}")
     hostname = socket.gethostname()
     conninfo = dataobj.pg_conn.info
     host = types.Host(

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -544,7 +544,7 @@ def pg_connect(
                 msg = str(err).replace("FATAL:", "")
                 raise SystemExit("pg_activity: FATAL: %s" % clean_str(msg))
             else:
-                raise Exception("Could not connect to PostgreSQL")
+                raise
         except pg.ProgrammingError as err:
             errmsg = str(err).strip()
             if errmsg.startswith("invalid dsn"):


### PR DESCRIPTION
This avoids showing a traceback to the user. To do so, we simply let the OperationalError propagate from data.pg_connect(), eventually catch it in cli.main() and exit with a nice error message.

Before:
```
$ pg_activity
Traceback (most recent call last):
  File "/home/denis/src/pg_activity/pgactivity/data.py", line 517, in pg_connect
    data = Data.pg_connect(
           ^^^^^^^^^^^^^^^^
  File "/home/denis/src/pg_activity/pgactivity/data.py", line 93, in pg_connect
    pg_conn = pg.connect(
              ^^^^^^^^^^^
  File "/home/denis/src/pg_activity/pgactivity/pg.py", line 59, in connect
    conn = psycopg.connect(dsn, autocommit=True, row_factory=dict_row, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denis/src/pg_activity/.venv/lib/python3.11/site-packages/psycopg/connection.py", line 728, in connect
    raise ex.with_traceback(None)
psycopg.OperationalError: connection is bad: No such file or directory
	Is the server running locally and accepting connections on that socket?

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/denis/src/pg_activity/.venv/bin/pg_activity", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/denis/src/pg_activity/pgactivity/cli.py", line 394, in main
    dataobj = data.pg_connect(
              ^^^^^^^^^^^^^^^^
  File "/home/denis/src/pg_activity/pgactivity/data.py", line 541, in pg_connect
    raise Exception("Could not connect to PostgreSQL")
Exception: Could not connect to PostgreSQL
```
After:
```
$ pg_activity
could not connect to PostgreSQL: connection is bad: No such file or directory
	Is the server running locally and accepting connections on that socket?
```