### PR TITLE
Add support for configuration profiles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.7"
+          - python: "3.8"
             psycopg: "psycopg2"
           - python: "3.12"
             psycopg: "psycopg3"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
         exclude: tests/test_*.txt
   - repo: local
     hooks:
+      - id: pyupgrade
+        name: pyupgrade
+        entry: pyupgrade --py38-plus --exit-zero-even-if-changed
+        language: system
+        types: [python]
       - id: black
         name: black
         entry: black --check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 * The *rollback ratio* is now displayed in the "global" header (#385).
+* Make header's sections display configurable through the `[header]` section of
+  the configuration file.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * Fix retrieval of I/O statistics on BSD systems (#393).
 * Fix spelling mistakes in the man page.
 
+### Removed
+
+* Python 3.7 is no longer supported.
+
 ### Misc
 
 * Document how to *hack* on pg\_activity in the `README`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * The *rollback ratio* is now displayed in the "global" header (#385).
 * Make header's sections display configurable through the `[header]` section of
   the configuration file.
+* Configuration profiles can now be defined at
+  `${XDG_CONFIG_HOME:~/.config}/pg_activity/<profile>.conf` or
+  `/etc/pg_activity/<profile>.conf` as selected from the command line through
+  `--profile <profile>`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * The help text for `K` action, displayed in the footer, has been rephrased as
   "terminate underlying session".
+* Rephrase the help text of `--no-{inst,sys,proc}-info` options and group them
+  into a dedicated section of `--help` output.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -130,12 +130,14 @@ ex:
       --no-wait             Disable W.
       --no-app-name         Disable App.
 
+    Header display options:
+      --no-inst-info        Display instance information.
+      --no-sys-info         Display system information.
+      --no-proc-info        Display workers process information.
+
     Other display options:
       --hide-queries-in-logs
                             Disable log_min_duration_statements and log_min_duration_sample for pg_activity.
-      --no-inst-info        Display instance information in header.
-      --no-sys-info         Display system information in header.
-      --no-proc-info        Display workers process information in header.
       --refresh REFRESH     Refresh rate. Values: 0.5, 1, 2, 3, 4, 5 (default: 2).
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -146,8 +146,14 @@ ex:
 read from `${XDG_CONFIG_HOME:~/.config}/pg_activity.conf` or
 `/etc/pg_activity.conf` in that order. Command-line options may override
 configuration file settings.
-This is used to control how columns in the processes table are rendered, e.g.:
+This is used to control how columns in the processes table are rendered or which
+items of the header should be displayed, e.g.:
 ```ini
+[header]
+show_instance = yes
+show_system = yes
+show_workers = no
+
 [client]
 hidden = yes
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ ex:
 
     pg_activity [options] [connection string]
 
+    Configuration:
+      --profile PROFILE     Configuration profile matching a PROFILE.conf file in
+                            ${XDG_CONFIG_HOME:~/.config}/pg_activity/ or
+                            /etc/pg_activity/.
+
     Options:
       --blocksize BLOCKSIZE
                             Filesystem blocksize (default: 4096).
@@ -142,7 +147,7 @@ ex:
 
 ## Configuration
 
-`pg_activity` may be configured through configuration file, in [INI format][],
+`pg_activity` may be configured through a configuration file, in [INI format][],
 read from `${XDG_CONFIG_HOME:~/.config}/pg_activity.conf` or
 `/etc/pg_activity.conf` in that order. Command-line options may override
 configuration file settings.
@@ -160,6 +165,13 @@ hidden = yes
 [database]
 width = 9
 ```
+
+Alternatively, the user might define *configuration profiles* in the form of
+files located at `${XDG_CONFIG_HOME:~/.config}/pg_activity/<my-profile>.conf` or
+`/etc/pg_activity/<my-profile>.conf`; these can then be used through the
+`--profile <my-profile>` command-line option. The format of these files is the
+same as the main configuration file.
+
 
 [INI format]: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pg\_activity releases. Before submitting a bug report here:
 
 ## From PyPI
 
-pg\_activity can be installed using pip on Python 3.7 or later along with
+pg\_activity can be installed using pip on Python 3.8 or later along with
 psycopg:
 
     $ python3 -m pip install "pg_activity[psycopg]"

--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "PG_ACTIVITY 1"
-.TH PG_ACTIVITY 1 "2023-06-01" "pg_activity 3.4.2" "Command line tool for PostgreSQL server activity monitoring."
+.TH PG_ACTIVITY 1 "2024-02-20" "pg_activity 3.4.2" "Command line tool for PostgreSQL server activity monitoring."
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -490,23 +490,25 @@ required by another session. It shows following information:
 .Vb 1
 \&        Disable App.
 .Ve
-.SS "\s-1OTHER DISPLAY OPTIONS\s0"
-.IX Subsection "OTHER DISPLAY OPTIONS"
+.SS "\s-1HEADER DISPLAY OPTIONS\s0"
+.IX Subsection "HEADER DISPLAY OPTIONS"
 .IP "\fB\-\-no\-inst\-info\fR" 2
 .IX Item "--no-inst-info"
 .Vb 1
-\&        Display instance information in header.
+\&        Hide instance information.
 .Ve
 .IP "\fB\-\-no\-sys\-info\fR" 2
 .IX Item "--no-sys-info"
 .Vb 1
-\&        Display system information in header.
+\&        Hide system information.
 .Ve
 .IP "\fB\-\-no\-proc\-info\fR" 2
 .IX Item "--no-proc-info"
 .Vb 1
-\&        Display workers process information in header.
+\&        Hide workers process information.
 .Ve
+.SS "\s-1OTHER DISPLAY OPTIONS\s0"
+.IX Subsection "OTHER DISPLAY OPTIONS"
 .IP "\fB\-\-refresh\fR" 2
 .IX Item "--refresh"
 .Vb 1

--- a/docs/man/pg_activity.1
+++ b/docs/man/pg_activity.1
@@ -347,6 +347,13 @@ required by another session. It shows following information:
 .PD
 .SH "COMMAND-LINE OPTIONS"
 .IX Header "COMMAND-LINE OPTIONS"
+.SS "\s-1CONFIGURATION\s0"
+.IX Subsection "CONFIGURATION"
+.IP "\fB\-\-profile=PROFILE\fR" 2
+.IX Item "--profile=PROFILE"
+.Vb 1
+\&        Configuration profile matching a PROFILE.conf file in ${XDG_CONFIG_HOME:~/.config}/pg_activity/ or /etc/pg_activity/.
+.Ve
 .SS "\s-1OPTIONS\s0"
 .IX Subsection "OPTIONS"
 .IP "\fB\-\-blocksize=BLOCKSIZE\fR" 2

--- a/docs/man/pg_activity.pod
+++ b/docs/man/pg_activity.pod
@@ -230,6 +230,16 @@ required by another session. It shows following information:
 
 =head1 COMMAND-LINE OPTIONS
 
+=head2 CONFIGURATION
+
+=over 2
+
+=item B<--profile=PROFILE>
+
+	Configuration profile matching a PROFILE.conf file in ${XDG_CONFIG_HOME:~/.config}/pg_activity/ or /etc/pg_activity/.
+
+=back
+
 =head2 OPTIONS
 
 =over 2

--- a/docs/man/pg_activity.pod
+++ b/docs/man/pg_activity.pod
@@ -358,21 +358,27 @@ required by another session. It shows following information:
 
 =back
 
-=head2 OTHER DISPLAY OPTIONS
+=head2 HEADER DISPLAY OPTIONS
 
 =over 2
 
 =item B<--no-inst-info>
 
-	Display instance information in header.
+	Hide instance information.
 
 =item B<--no-sys-info>
 
-	Display system information in header.
+	Hide system information.
 
 =item B<--no-proc-info>
 
-	Display workers process information in header.
+	Hide workers process information.
+
+=back
+
+=head2 OTHER DISPLAY OPTIONS
+
+=over 2
 
 =item B<--refresh>
 

--- a/pgactivity/activities.py
+++ b/pgactivity/activities.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import builtins
 import os
 import time
-from typing import Sequence, TypeVar
+from typing import TypeVar
 from warnings import catch_warnings, simplefilter
 
 import attr
 import psutil
 
+from .compat import Sequence
 from .types import (
     BlockingProcess,
     IOCounter,

--- a/pgactivity/activities.py
+++ b/pgactivity/activities.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import builtins
 import os
 import time
-from typing import Dict, List, Optional, Sequence, Tuple, TypeVar
+from typing import Sequence, TypeVar
 from warnings import catch_warnings, simplefilter
 
 import attr
@@ -21,7 +23,7 @@ from .types import (
 )
 
 
-def sys_get_proc(pid: int) -> Optional[SystemProcess]:
+def sys_get_proc(pid: int) -> SystemProcess | None:
     """Return a SystemProcess instance matching given pid or None if access with psutil
     is not possible.
     """
@@ -53,9 +55,9 @@ def sys_get_proc(pid: int) -> Optional[SystemProcess]:
 
 def ps_complete(
     pg_processes: Sequence[RunningProcess],
-    processes: Dict[int, SystemProcess],
+    processes: dict[int, SystemProcess],
     fs_blocksize: int,
-) -> Tuple[List[LocalRunningProcess], IOCounter, IOCounter]:
+) -> tuple[list[LocalRunningProcess], IOCounter, IOCounter]:
     """Transform the sequence of 'pg_processes' (RunningProcess) as LocalRunningProcess
     with local system information from the 'processes' map. Return LocalRunningProcess
     list, as well as read and write IO counters.
@@ -139,7 +141,7 @@ def ps_complete(
 T = TypeVar("T", RunningProcess, WaitingProcess, BlockingProcess, LocalRunningProcess)
 
 
-def sorted(processes: List[T], *, key: SortKey, reverse: bool = False) -> List[T]:
+def sorted(processes: list[T], *, key: SortKey, reverse: bool = False) -> list[T]:
     """Return processes sorted.
 
     >>> from ipaddress import IPv4Interface, ip_address
@@ -314,12 +316,12 @@ def update_max_iops(max_iops: int, read_count: float, write_count: float) -> int
     return max(int(read_count + write_count), max_iops)
 
 
-def get_load_average() -> Tuple[float, float, float]:
+def get_load_average() -> tuple[float, float, float]:
     """Get load average"""
     return os.getloadavg()
 
 
-def get_mem_swap() -> Tuple[MemoryInfo, SwapInfo]:
+def get_mem_swap() -> tuple[MemoryInfo, SwapInfo]:
     """Get memory and swap usage"""
     with catch_warnings():
         simplefilter("ignore", RuntimeWarning)
@@ -335,7 +337,7 @@ def get_mem_swap() -> Tuple[MemoryInfo, SwapInfo]:
     )
 
 
-def mem_swap_load() -> Tuple[MemoryInfo, SwapInfo, LoadAverage]:
+def mem_swap_load() -> tuple[MemoryInfo, SwapInfo, LoadAverage]:
     """Read memory, swap and load average from Data object."""
     memory, swap = get_mem_swap()
     load = LoadAverage(*get_load_average())

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -319,7 +319,7 @@ def get_parser() -> ArgumentParser:
     # --no-inst-info
     group.add_argument(
         "--no-inst-info",
-        dest="show_instance_info_in_header",
+        dest="header_show_instance",
         action="store_false",
         help="Hide instance information.",
         default=True,
@@ -327,7 +327,7 @@ def get_parser() -> ArgumentParser:
     # --no-sys-info
     group.add_argument(
         "--no-sys-info",
-        dest="show_system_info_in_header",
+        dest="header_show_system",
         action="store_false",
         help="Hide system information.",
         default=True,
@@ -335,7 +335,7 @@ def get_parser() -> ArgumentParser:
     # --no-proc-info
     group.add_argument(
         "--no-proc-info",
-        dest="show_worker_info_in_header",
+        dest="header_show_workers",
         action="store_false",
         help="Hide workers process information.",
         default=True,

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -322,7 +322,7 @@ def get_parser() -> ArgumentParser:
         dest="header_show_instance",
         action="store_false",
         help="Hide instance information.",
-        default=True,
+        default=None,
     )
     # --no-sys-info
     group.add_argument(
@@ -330,7 +330,7 @@ def get_parser() -> ArgumentParser:
         dest="header_show_system",
         action="store_false",
         help="Hide system information.",
-        default=True,
+        default=None,
     )
     # --no-proc-info
     group.add_argument(
@@ -338,7 +338,7 @@ def get_parser() -> ArgumentParser:
         dest="header_show_workers",
         action="store_false",
         help="Hide workers process information.",
-        default=True,
+        default=None,
     )
 
     group = parser.add_argument_group("Other display options")

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -315,6 +315,32 @@ def get_parser() -> ArgumentParser:
         default=False,
     )
 
+    group = parser.add_argument_group("Header display options")
+    # --no-inst-info
+    group.add_argument(
+        "--no-inst-info",
+        dest="show_instance_info_in_header",
+        action="store_false",
+        help="Hide instance information.",
+        default=True,
+    )
+    # --no-sys-info
+    group.add_argument(
+        "--no-sys-info",
+        dest="show_system_info_in_header",
+        action="store_false",
+        help="Hide system information.",
+        default=True,
+    )
+    # --no-proc-info
+    group.add_argument(
+        "--no-proc-info",
+        dest="show_worker_info_in_header",
+        action="store_false",
+        help="Hide workers process information.",
+        default=True,
+    )
+
     group = parser.add_argument_group("Other display options")
     # --hide-queries-in-logs
     group.add_argument(
@@ -323,30 +349,6 @@ def get_parser() -> ArgumentParser:
         action="store_true",
         help="Disable log_min_duration_statements and log_min_duration_sample for pg_activity.",
         default=False,
-    )
-    # --no-inst-info
-    group.add_argument(
-        "--no-inst-info",
-        dest="show_instance_info_in_header",
-        action="store_false",
-        help="Display instance information in header.",
-        default=True,
-    )
-    # --no-sys-info
-    group.add_argument(
-        "--no-sys-info",
-        dest="show_system_info_in_header",
-        action="store_false",
-        help="Display system information in header.",
-        default=True,
-    )
-    # --no-proc-info
-    group.add_argument(
-        "--no-proc-info",
-        dest="show_worker_info_in_header",
-        action="store_false",
-        help="Display workers process information in header.",
-        default=True,
     )
     # --refresh
     group.add_argument(

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -61,6 +61,17 @@ def get_parser() -> ArgumentParser:
     )
 
     group = parser.add_argument_group(
+        "Configuration",
+    )
+    group.add_argument(
+        "--profile",
+        help=(
+            "Configuration profile matching a PROFILE.conf file in "
+            "${XDG_CONFIG_HOME:~/.config}/pg_activity/ or /etc/pg_activity/."
+        ),
+    )
+
+    group = parser.add_argument_group(
         "Options",
     )
     # --blocksize
@@ -390,8 +401,8 @@ def main() -> None:
         args.notempfile = True
 
     try:
-        cfg = Configuration.lookup()
-    except ConfigurationError as e:
+        cfg = Configuration.lookup(args.profile)
+    except (ConfigurationError, FileNotFoundError) as e:
         parser.error(str(e))
 
     try:

--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import socket
@@ -5,7 +7,6 @@ import sys
 import time
 from argparse import ArgumentParser
 from io import StringIO
-from typing import Optional
 
 from blessed import Terminal
 
@@ -14,7 +15,7 @@ from .config import Configuration, ConfigurationError
 from .pg import OperationalError
 
 
-def configure_logger(debug_file: Optional[str] = None) -> StringIO:
+def configure_logger(debug_file: str | None = None) -> StringIO:
     logger = logging.getLogger("pgactivity")
     logger.setLevel(logging.DEBUG)
 

--- a/pgactivity/compat.py
+++ b/pgactivity/compat.py
@@ -1,12 +1,37 @@
 from __future__ import annotations
 
 import operator
+import sys
 from importlib.metadata import version
 from typing import Any
 
 import attr
 import attr.validators
 import blessed
+
+__all__ = [
+    "Callable",
+    "Dict",
+    "Iterable",
+    "Iterator",
+    "Mapping",
+    "MutableSet",
+    "Sequence",
+]
+
+if sys.version_info >= (3, 9):
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Iterator,
+        Mapping,
+        MutableSet,
+        Sequence,
+    )
+
+    Dict = dict
+else:
+    from typing import Callable, Dict, Iterable, Iterator, Mapping, MutableSet, Sequence
 
 ATTR_VERSION = tuple(int(x) for x in version("attrs").split(".", 2)[:2])
 BLESSED_VERSION = tuple(int(x) for x in version("blessed").split(".", 2)[:2])

--- a/pgactivity/compat.py
+++ b/pgactivity/compat.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import operator
 from importlib.metadata import version
-from typing import Any, Dict
+from typing import Any
 
 import attr
 import attr.validators
@@ -11,7 +13,7 @@ BLESSED_VERSION = tuple(int(x) for x in version("blessed").split(".", 2)[:2])
 
 if ATTR_VERSION < (18, 1):
 
-    def fields_dict(cls: Any) -> Dict[str, Any]:
+    def fields_dict(cls: Any) -> dict[str, Any]:
         return {a.name: a for a in cls.__attrs_attrs__}
 
 else:

--- a/pgactivity/compat.py
+++ b/pgactivity/compat.py
@@ -1,15 +1,10 @@
 import operator
-import sys
+from importlib.metadata import version
 from typing import Any, Dict
 
 import attr
 import attr.validators
 import blessed
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
 
 ATTR_VERSION = tuple(int(x) for x in version("attrs").split(".", 2)[:2])
 BLESSED_VERSION = tuple(int(x) for x in version("blessed").split(".", 2)[:2])

--- a/pgactivity/config.py
+++ b/pgactivity/config.py
@@ -190,10 +190,7 @@ class HeaderSection(BaseSectionMixin):
     def from_config_section(cls: type[_T], section: configparser.SectionProxy) -> _T:
         values: dict[str, bool] = {}
         for optname in cls.check_options(section):
-            try:
-                value = section.getboolean(optname)
-            except configparser.NoOptionError:
-                continue
+            value = section.getboolean(optname)
             if value is not None:
                 values[optname] = value
         return cls(**values)
@@ -210,17 +207,10 @@ class UISection(BaseSectionMixin):
     def from_config_section(cls: type[_T], section: configparser.SectionProxy) -> _T:
         cls.check_options(section)
         values: dict[str, Any] = {}
-        try:
-            hidden = section.getboolean("hidden")
-        except configparser.NoOptionError:
-            pass
-        else:
-            if hidden is not None:
-                values["hidden"] = hidden
-        try:
-            values["width"] = section.getint("width")
-        except configparser.NoOptionError:
-            pass
+        hidden = section.getboolean("hidden")
+        if hidden is not None:
+            values["hidden"] = hidden
+        values["width"] = section.getint("width")
         return cls(**values)
 
 

--- a/pgactivity/config.py
+++ b/pgactivity/config.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import configparser
 import enum
 import os
 from pathlib import Path
-from typing import IO, Any, Dict, List, Optional, Type, TypeVar
+from typing import IO, Any, Dict, TypeVar
 
 import attr
 from attr import validators
@@ -70,7 +72,7 @@ class Flag(enum.Flag):
     PID = enum.auto()
 
     @classmethod
-    def names(cls) -> List[str]:
+    def names(cls) -> list[str]:
         rv = []
         for f in cls:
             assert f.name
@@ -78,14 +80,14 @@ class Flag(enum.Flag):
         return rv
 
     @classmethod
-    def all(cls) -> "Flag":
+    def all(cls) -> Flag:
         value = cls(0)
         for f in cls:
             value |= f
         return value
 
     @classmethod
-    def from_config(cls, config: "Configuration") -> "Flag":
+    def from_config(cls, config: Configuration) -> Flag:
         value = cls(0)
         for f in cls:
             assert f.name is not None
@@ -102,7 +104,7 @@ class Flag(enum.Flag):
     @classmethod
     def load(
         cls,
-        config: Optional["Configuration"],
+        config: Configuration | None,
         *,
         is_local: bool,
         noappname: bool,
@@ -117,7 +119,7 @@ class Flag(enum.Flag):
         nowait: bool,
         nowrite: bool,
         **kwargs: Any,
-    ) -> "Flag":
+    ) -> Flag:
         """Build a Flag value from command line options."""
         if config:
             flag = cls.from_config(config)
@@ -163,13 +165,13 @@ class Flag(enum.Flag):
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class UISection:
     hidden: bool = False
-    width: Optional[int] = attr.ib(default=None, validator=validators.optional(gt(0)))
+    width: int | None = attr.ib(default=None, validator=validators.optional(gt(0)))
 
     _T = TypeVar("_T", bound="UISection")
 
     @classmethod
-    def from_config_section(cls: Type[_T], section: configparser.SectionProxy) -> _T:
-        values: Dict[str, Any] = {}
+    def from_config_section(cls: type[_T], section: configparser.SectionProxy) -> _T:
+        values: dict[str, Any] = {}
         known_options = {f.name: f for f in attr.fields(cls)}
         unknown_options = set(section) - set(known_options)
         if unknown_options:
@@ -196,7 +198,7 @@ class Configuration(Dict[str, UISection]):
     _T = TypeVar("_T", bound="Configuration")
 
     @classmethod
-    def parse(cls: Type[_T], f: IO[str], name: str) -> _T:
+    def parse(cls: type[_T], f: IO[str], name: str) -> _T:
         r"""Parse configuration from 'f'.
 
         >>> from io import StringIO
@@ -260,11 +262,11 @@ class Configuration(Dict[str, UISection]):
 
     @classmethod
     def lookup(
-        cls: Type[_T],
+        cls: type[_T],
         *,
         user_config_home: Path = USER_CONFIG_HOME,
         etc: Path = ETC,
-    ) -> Optional[_T]:
+    ) -> _T | None:
         for base in (user_config_home, etc):
             fpath = base / "pg_activity.conf"
             if fpath.exists():

--- a/pgactivity/handlers.py
+++ b/pgactivity/handlers.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from blessed.keyboard import Keystroke
 
@@ -8,7 +8,7 @@ from .types import DurationMode, QueryMode, SortKey, enum_next
 
 
 def refresh_time(
-    key: Optional[str], value: float, minimum: float = 0.5, maximum: float = 5
+    key: str | None, value: float, minimum: float = 0.5, maximum: float = 5
 ) -> float:
     """Return an updated refresh time interval from input key respecting bounds.
 
@@ -66,7 +66,7 @@ def wrap_query(key: Keystroke, wrap: bool) -> bool:
     return wrap
 
 
-def query_mode(key: Keystroke) -> Optional[QueryMode]:
+def query_mode(key: Keystroke) -> QueryMode | None:
     """Return the query mode matching input key or None.
 
     >>> import curses
@@ -86,9 +86,7 @@ def query_mode(key: Keystroke) -> Optional[QueryMode]:
     return keys.QUERYMODE_FROM_KEYS.get(key)
 
 
-def sort_key_for(
-    key: Keystroke, query_mode: QueryMode, flag: Flag
-) -> Optional[SortKey]:
+def sort_key_for(key: Keystroke, query_mode: QueryMode, flag: Flag) -> SortKey | None:
     """Return the sort key matching input key or None.
 
     >>> from blessed.keyboard import Keystroke as k

--- a/pgactivity/keys.py
+++ b/pgactivity/keys.py
@@ -49,7 +49,7 @@ SORTBY_TIME = "t"
 SORTBY_CPU = "c"
 HEADER_TOGGLE_SYSTEM = "s"
 HEADER_TOGGLE_INSTANCE = "i"
-HEADER_TOGGLE_WORKER = "o"
+HEADER_TOGGLE_WORKERS = "o"
 
 
 def is_process_next(key: Keystroke) -> bool:
@@ -84,16 +84,16 @@ def is_process_last(key: Keystroke) -> bool:
     return key.name == PROCESS_LAST
 
 
-def is_toggle_header_sys_info(key: Keystroke) -> bool:
+def is_toggle_header_system(key: Keystroke) -> bool:
     return key == HEADER_TOGGLE_SYSTEM
 
 
-def is_toggle_header_inst_info(key: Keystroke) -> bool:
+def is_toggle_header_instance(key: Keystroke) -> bool:
     return key == HEADER_TOGGLE_INSTANCE
 
 
-def is_toggle_header_worker_info(key: Keystroke) -> bool:
-    return key == HEADER_TOGGLE_WORKER
+def is_toggle_header_workers(key: Keystroke) -> bool:
+    return key == HEADER_TOGGLE_WORKERS
 
 
 EXIT_KEY = Key(EXIT, "quit")
@@ -115,7 +115,7 @@ BINDINGS: list[Key] = [
     Key("R", "force refresh"),
     Key(HEADER_TOGGLE_SYSTEM, "Display system information in header", local_only=True),
     Key(HEADER_TOGGLE_INSTANCE, "Display general instance information in header"),
-    Key(HEADER_TOGGLE_WORKER, "Display worker information in header"),
+    Key(HEADER_TOGGLE_WORKERS, "Display worker information in header"),
     EXIT_KEY,
 ]
 

--- a/pgactivity/keys.py
+++ b/pgactivity/keys.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import curses
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 import attr
 from blessed.keyboard import Keystroke
@@ -11,7 +13,7 @@ from .types import QueryMode
 class Key:
     value: str
     description: str
-    name: Optional[str] = None
+    name: str | None = None
     local_only: bool = False
 
     def __eq__(self, other: Any) -> bool:
@@ -97,7 +99,7 @@ def is_toggle_header_worker_info(key: Keystroke) -> bool:
 EXIT_KEY = Key(EXIT, "quit")
 PAUSE_KEY = Key(SPACE, "pause/unpause", "Space")
 
-BINDINGS: List[Key] = [
+BINDINGS: list[Key] = [
     Key("Up/Down", "scroll process list"),
     PAUSE_KEY,
     Key(SORTBY_CPU, "sort by CPU% desc. (activities)", local_only=True),
@@ -118,7 +120,7 @@ BINDINGS: List[Key] = [
 ]
 
 
-def _sequence_by_int(v: int) -> Tuple[str, str, int]:
+def _sequence_by_int(v: int) -> tuple[str, str, int]:
     """
     >>> _sequence_by_int(11)
     ('F11', '11', 275)
@@ -137,6 +139,6 @@ QUERYMODE_FROM_KEYS = {
 }
 
 
-MODES: List[Key] = [
+MODES: list[Key] = [
     Key("/".join(KEYS_BY_QUERYMODE[qm][:-1]), qm.value) for qm in QueryMode
 ]

--- a/pgactivity/pg.py
+++ b/pgactivity/pg.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Callable, Dict, Sequence, TypeVar, overload
+from typing import Any, TypeVar, overload
+
+from .compat import Callable, Dict, Sequence
 
 Row = TypeVar("Row")
 

--- a/pgactivity/pg.py
+++ b/pgactivity/pg.py
@@ -1,16 +1,8 @@
+from __future__ import annotations
+
 import logging
 import os
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, Dict, Sequence, TypeVar, overload
 
 Row = TypeVar("Row")
 
@@ -71,13 +63,13 @@ try:
     def server_version(conn: Connection) -> int:
         return conn.info.server_version
 
-    def connection_parameters(conn: Connection) -> Dict[str, Any]:
+    def connection_parameters(conn: Connection) -> dict[str, Any]:
         return conn.info.get_parameters()
 
     def execute(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
     ) -> None:
         conn.execute(query, args, prepare=True)
 
@@ -92,8 +84,8 @@ try:
     ) -> psycopg.Cursor[psycopg.rows.DictRow]: ...
 
     def cursor(
-        conn: Connection, mkrow: Optional[Callable[..., Row]], text_as_bytes: bool
-    ) -> Union[psycopg.Cursor[psycopg.rows.DictRow], psycopg.Cursor[Row]]:
+        conn: Connection, mkrow: Callable[..., Row] | None, text_as_bytes: bool
+    ) -> psycopg.Cursor[psycopg.rows.DictRow] | psycopg.Cursor[Row]:
         if mkrow is not None:
             cur = conn.cursor(row_factory=psycopg.rows.kwargs_row(mkrow))
         else:
@@ -105,8 +97,8 @@ try:
     @overload
     def fetchone(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
         mkrow: Callable[..., Row],
         text_as_bytes: bool = False,
@@ -115,20 +107,20 @@ try:
     @overload
     def fetchone(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
         text_as_bytes: bool = False,
-    ) -> Dict[str, Any]: ...
+    ) -> dict[str, Any]: ...
 
     def fetchone(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
-        mkrow: Optional[Callable[..., Row]] = None,
+        mkrow: Callable[..., Row] | None = None,
         text_as_bytes: bool = False,
-    ) -> Union[Dict[str, Any], Row]:
+    ) -> dict[str, Any] | Row:
         with cursor(conn, mkrow, text_as_bytes) as cur:
             row = cur.execute(query, args, prepare=True).fetchone()
         assert row is not None
@@ -137,30 +129,30 @@ try:
     @overload
     def fetchall(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
         mkrow: Callable[..., Row],
         text_as_bytes: bool = False,
-    ) -> List[Row]: ...
+    ) -> list[Row]: ...
 
     @overload
     def fetchall(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
         text_as_bytes: bool = False,
-    ) -> List[Dict[str, Any]]: ...
+    ) -> list[dict[str, Any]]: ...
 
     def fetchall(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
         text_as_bytes: bool = False,
-        mkrow: Optional[Callable[..., Row]] = None,
-    ) -> Union[List[Dict[str, Any]], List[Row]]:
+        mkrow: Callable[..., Row] | None = None,
+    ) -> list[dict[str, Any]] | list[Row]:
         with cursor(conn, mkrow, text_as_bytes) as cur:
             return cur.execute(query, args, prepare=True).fetchall()
 
@@ -212,25 +204,25 @@ except ImportError:
     def server_version(conn: Connection) -> int:
         return conn.server_version  # type: ignore[attr-defined, no-any-return]
 
-    def connection_parameters(conn: Connection) -> Dict[str, Any]:
+    def connection_parameters(conn: Connection) -> dict[str, Any]:
         return conn.info.dsn_parameters  # type: ignore[attr-defined, no-any-return]
 
     def execute(
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
     ) -> None:
         with conn.cursor() as cur:
             cur.execute(query, args)
 
     def fetchone(  # type: ignore[no-redef]
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
-        mkrow: Optional[Callable[..., Row]] = None,
+        mkrow: Callable[..., Row] | None = None,
         text_as_bytes: bool = False,
-    ) -> Union[Dict[str, Any], Row]:
+    ) -> dict[str, Any] | Row:
         with conn.cursor() as cur:
             if text_as_bytes:
                 psycopg2.extensions.register_type(psycopg2.extensions.BYTES, cur)  # type: ignore[arg-type]
@@ -243,12 +235,12 @@ except ImportError:
 
     def fetchall(  # type: ignore[no-redef]
         conn: Connection,
-        query: Union[str, sql.Composed],
-        args: Union[None, Sequence[Any], Dict[str, Any]] = None,
+        query: str | sql.Composed,
+        args: None | Sequence[Any] | dict[str, Any] = None,
         *,
-        mkrow: Optional[Callable[..., Row]] = None,
+        mkrow: Callable[..., Row] | None = None,
         text_as_bytes: bool = False,
-    ) -> Union[List[Dict[str, Any]], List[Row]]:
+    ) -> list[dict[str, Any]] | list[Row]:
         with conn.cursor() as cur:
             if text_as_bytes:
                 psycopg2.extensions.register_type(psycopg2.extensions.BYTES, cur)  # type: ignore[arg-type]

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -278,7 +278,7 @@ class UI:
                 key="database",
                 name="DATABASE(*)" if filters.dbname else "DATABASE",
                 min_width=max_db_length,
-                transform=functools.lru_cache()(
+                transform=functools.lru_cache(
                     lambda v: utils.ellipsis(v, width=16) if v else "",
                 ),
                 sort_key=None,

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -4,25 +4,14 @@ import enum
 import functools
 from datetime import timedelta
 from ipaddress import IPv4Address, IPv6Address
-from typing import (
-    Any,
-    Callable,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableSet,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Tuple, TypeVar, Union, overload
 
 import attr
 import psutil
 from attr import validators
 
 from . import colors, compat, pg, utils
+from .compat import Callable, Iterable, Iterator, Mapping, MutableSet, Sequence
 from .config import Configuration, Flag
 
 

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -194,9 +194,64 @@ class Column:
 
 
 @attr.s(auto_attribs=True, slots=True)
+class UIHeader:
+    """Configuration for the header of the UI."""
+
+    show_instance: bool = True
+    show_system: bool = True
+    show_workers: bool = True
+
+    def toggle_system(self) -> None:
+        """Toggle the 'show_system' attribute.
+
+        >>> h = UIHeader()
+        >>> h.show_system
+        True
+        >>> h.toggle_system()
+        >>> h.show_system
+        False
+        >>> h.toggle_system()
+        >>> h.show_system
+        True
+        """
+        self.show_system = not self.show_system
+
+    def toggle_instance(self) -> None:
+        """Toggle the 'show_instance' attribute.
+
+        >>> h = UIHeader()
+        >>> h.show_instance
+        True
+        >>> h.toggle_instance()
+        >>> h.show_instance
+        False
+        >>> h.toggle_instance()
+        >>> h.show_instance
+        True
+        """
+        self.show_instance = not self.show_instance
+
+    def toggle_workers(self) -> None:
+        """Toggle the 'show_workers' attribute.
+
+        >>> h = UIHeader()
+        >>> h.show_workers
+        True
+        >>> h.toggle_workers()
+        >>> h.show_workers
+        False
+        >>> h.toggle_workers()
+        >>> h.show_workers
+        True
+        """
+        self.show_workers = not self.show_workers
+
+
+@attr.s(auto_attribs=True, slots=True)
 class UI:
     """State of the UI."""
 
+    header: UIHeader
     columns_by_querymode: Mapping[QueryMode, tuple[Column, ...]]
     min_duration: float = 0.0
     duration_mode: DurationMode = attr.ib(
@@ -208,13 +263,11 @@ class UI:
     refresh_time: float | int = 2
     in_pause: bool = False
     interactive_timeout: int | None = None
-    show_instance_info_in_header: bool = True
-    show_system_info_in_header: bool = True
-    show_worker_info_in_header: bool = True
 
     @classmethod
     def make(
         cls,
+        header: UIHeader | None = None,
         config: Configuration | None = None,
         flag: Flag = Flag.all(),
         *,
@@ -222,6 +275,9 @@ class UI:
         filters: Filters = NO_FILTER,
         **kwargs: Any,
     ) -> UI:
+        if header is None:
+            header = UIHeader()
+
         possible_columns: dict[str, Column] = {}
 
         def add_column(key: str, name: str, **kwargs: Any) -> None:
@@ -429,7 +485,7 @@ class UI:
                     pass
 
         columns_by_querymode = {qm: tuple(make_columns_for(qm)) for qm in QueryMode}
-        return cls(columns_by_querymode=columns_by_querymode, **kwargs)
+        return cls(header=header, columns_by_querymode=columns_by_querymode, **kwargs)
 
     def interactive(self) -> bool:
         return self.interactive_timeout is not None
@@ -499,51 +555,6 @@ class UI:
         False
         """
         self.in_pause = not self.in_pause
-
-    def toggle_system_info_in_header(self) -> None:
-        """Toggle the 'show_system_info_in_header' attribute.
-
-        >>> ui = UI.make()
-        >>> ui.show_system_info_in_header
-        True
-        >>> ui.toggle_system_info_in_header()
-        >>> ui.show_system_info_in_header
-        False
-        >>> ui.toggle_system_info_in_header()
-        >>> ui.show_system_info_in_header
-        True
-        """
-        self.show_system_info_in_header = not self.show_system_info_in_header
-
-    def toggle_instance_info_in_header(self) -> None:
-        """Toggle the 'show_instance_info_in_header' attribute.
-
-        >>> ui = UI.make()
-        >>> ui.show_instance_info_in_header
-        True
-        >>> ui.toggle_instance_info_in_header()
-        >>> ui.show_instance_info_in_header
-        False
-        >>> ui.toggle_instance_info_in_header()
-        >>> ui.show_instance_info_in_header
-        True
-        """
-        self.show_instance_info_in_header = not self.show_instance_info_in_header
-
-    def toggle_worker_info_in_header(self) -> None:
-        """Toggle the 'show_worker_info_in_header' attribute.
-
-        >>> ui = UI.make()
-        >>> ui.show_worker_info_in_header
-        True
-        >>> ui.toggle_worker_info_in_header()
-        >>> ui.show_worker_info_in_header
-        False
-        >>> ui.toggle_worker_info_in_header()
-        >>> ui.show_worker_info_in_header
-        True
-        """
-        self.show_worker_info_in_header = not self.show_worker_info_in_header
 
     def evolve(self, **changes: Any) -> None:
         """Return a new UI with 'changes' applied.

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 import functools
 from datetime import timedelta
@@ -5,16 +7,12 @@ from ipaddress import IPv4Address, IPv6Address
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
     Iterator,
-    List,
     Mapping,
     MutableSet,
-    Optional,
     Sequence,
     Tuple,
-    Type,
     TypeVar,
     Union,
     overload,
@@ -57,10 +55,10 @@ def enum_next(e: E) -> E:
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class Filters:
-    dbname: Optional[str] = None
+    dbname: str | None = None
 
     @classmethod
-    def from_options(cls, filters: Sequence[str]) -> "Filters":
+    def from_options(cls, filters: Sequence[str]) -> Filters:
         fields = compat.fields_dict(cls)
         attrs = {}
         for f in filters:
@@ -89,7 +87,7 @@ class SortKey(enum.Enum):
     duration = enum.auto()
 
     @classmethod
-    def default(cls) -> "SortKey":
+    def default(cls) -> SortKey:
         return cls.duration
 
 
@@ -100,7 +98,7 @@ class QueryMode(enum.Enum):
     blocking = "blocking queries"
 
     @classmethod
-    def default(cls) -> "QueryMode":
+    def default(cls) -> QueryMode:
         return cls.activities
 
 
@@ -155,14 +153,14 @@ class Column:
     key: str = attr.ib(repr=False)
     name: str
     mandatory: bool = False
-    sort_key: Optional[SortKey] = None
+    sort_key: SortKey | None = None
     min_width: int = attr.ib(default=0, repr=False)
-    max_width: Optional[int] = attr.ib(default=None, repr=False)
+    max_width: int | None = attr.ib(default=None, repr=False)
     justify: str = attr.ib(
         "left", validator=validators.in_(["left", "center", "right"])
     )
     transform: Callable[[Any], str] = attr.ib(default=if_none(""), repr=False)
-    color_key: Union[str, Callable[[Any], str]] = attr.ib(
+    color_key: str | Callable[[Any], str] = attr.ib(
         default=_color_key_marker, repr=False
     )
 
@@ -210,7 +208,7 @@ class Column:
 class UI:
     """State of the UI."""
 
-    columns_by_querymode: Mapping[QueryMode, Tuple[Column, ...]]
+    columns_by_querymode: Mapping[QueryMode, tuple[Column, ...]]
     min_duration: float = 0.0
     duration_mode: DurationMode = attr.ib(
         default=DurationMode.query, converter=DurationMode
@@ -218,9 +216,9 @@ class UI:
     wrap_query: bool = False
     sort_key: SortKey = attr.ib(default=SortKey.default(), converter=SortKey)
     query_mode: QueryMode = attr.ib(default=QueryMode.activities, converter=QueryMode)
-    refresh_time: Union[float, int] = 2
+    refresh_time: float | int = 2
     in_pause: bool = False
-    interactive_timeout: Optional[int] = None
+    interactive_timeout: int | None = None
     show_instance_info_in_header: bool = True
     show_system_info_in_header: bool = True
     show_worker_info_in_header: bool = True
@@ -228,14 +226,14 @@ class UI:
     @classmethod
     def make(
         cls,
-        config: Optional[Configuration] = None,
+        config: Configuration | None = None,
         flag: Flag = Flag.all(),
         *,
         max_db_length: int = 16,
         filters: Filters = NO_FILTER,
         **kwargs: Any,
-    ) -> "UI":
-        possible_columns: Dict[str, Column] = {}
+    ) -> UI:
+        possible_columns: dict[str, Column] = {}
 
         def add_column(key: str, name: str, **kwargs: Any) -> None:
             if config is not None:
@@ -388,7 +386,7 @@ class UI:
                 transform=utils.naturalsize,
             )
 
-        columns_key_by_querymode: Mapping[QueryMode, List[str]] = {
+        columns_key_by_querymode: Mapping[QueryMode, list[str]] = {
             QueryMode.activities: [
                 "pid",
                 "database",
@@ -604,7 +602,7 @@ class UI:
         else:
             raise ValueError(key)
 
-    def columns(self) -> Tuple[Column, ...]:
+    def columns(self) -> tuple[Column, ...]:
         """Return the tuple of Column for current mode.
 
         >>> flag = Flag.PID | Flag.DATABASE | Flag.APPNAME | Flag.RELATION
@@ -631,18 +629,18 @@ class SwapInfo:
     total: int
 
     @classmethod
-    def default(cls) -> "SwapInfo":
+    def default(cls) -> SwapInfo:
         return cls(0, 0, 0)
 
     @property
-    def pct_used(self) -> Optional[Pct]:
+    def pct_used(self) -> Pct | None:
         if self.total == 0:
             # account for the zero swap case (#318)
             return None
         return Pct(self.used * 100 / self.total)
 
     @property
-    def pct_free(self) -> Optional[Pct]:
+    def pct_free(self) -> Pct | None:
         if self.total == 0:
             # account for the zero swap case (#318)
             return None
@@ -657,23 +655,23 @@ class MemoryInfo:
     total: int
 
     @classmethod
-    def default(cls) -> "MemoryInfo":
+    def default(cls) -> MemoryInfo:
         return cls(0, 0, 0, 0)
 
     @property
-    def pct_used(self) -> Optional[Pct]:
+    def pct_used(self) -> Pct | None:
         if self.total == 0:
             return None
         return Pct(self.used * 100 / self.total)
 
     @property
-    def pct_free(self) -> Optional[Pct]:
+    def pct_free(self) -> Pct | None:
         if self.total == 0:
             return None
         return Pct(self.free * 100 / self.total)
 
     @property
-    def pct_bc(self) -> Optional[Pct]:
+    def pct_bc(self) -> Pct | None:
         if self.total == 0:
             return None
         return Pct(self.buff_cached * 100 / self.total)
@@ -686,7 +684,7 @@ class LoadAverage:
     avg15: float
 
     @classmethod
-    def default(cls) -> "LoadAverage":
+    def default(cls) -> LoadAverage:
         return cls(0.0, 0.0, 0.0)
 
 
@@ -696,7 +694,7 @@ class IOCounter:
     bytes: int
 
     @classmethod
-    def default(cls) -> "IOCounter":
+    def default(cls) -> IOCounter:
         return cls(0, 0)
 
 
@@ -713,10 +711,10 @@ class SystemInfo:
     def default(
         cls,
         *,
-        memory: Optional[MemoryInfo] = None,
-        swap: Optional[SwapInfo] = None,
-        load: Optional[LoadAverage] = None,
-    ) -> "SystemInfo":
+        memory: MemoryInfo | None = None,
+        swap: SwapInfo | None = None,
+        load: LoadAverage | None = None,
+    ) -> SystemInfo:
         """Zero-value builder.
 
         >>> SystemInfo.default()  # doctest: +NORMALIZE_WHITESPACE
@@ -771,19 +769,19 @@ class ServerInformation:
     total: int
     waiting: int
     max_connections: int
-    autovacuum_workers: Optional[int]
+    autovacuum_workers: int | None
     autovacuum_max_workers: int
-    logical_replication_workers: Optional[int]
-    parallel_workers: Optional[int]
-    max_logical_replication_workers: Optional[int]
-    max_parallel_workers: Optional[int]
-    max_worker_processes: Optional[int]
-    max_wal_senders: Optional[int]
-    max_replication_slots: Optional[int]
-    wal_senders: Optional[int]
-    wal_receivers: Optional[int]
-    replication_slots: Optional[int]
-    temporary_file: Optional[TempFileInfo]
+    logical_replication_workers: int | None
+    parallel_workers: int | None
+    max_logical_replication_workers: int | None
+    max_parallel_workers: int | None
+    max_worker_processes: int | None
+    max_wal_senders: int | None
+    max_replication_slots: int | None
+    wal_senders: int | None
+    wal_receivers: int | None
+    replication_slots: int | None
+    temporary_file: TempFileInfo | None
     # Computed in data.pg_get_server_information()
     size_evolution: float
     tps: int
@@ -791,15 +789,15 @@ class ServerInformation:
     update_per_second: int
     delete_per_second: int
     tuples_returned_per_second: int
-    cache_hit_ratio_last_snap: Optional[Pct] = attr.ib(
+    cache_hit_ratio_last_snap: Pct | None = attr.ib(
         converter=attr.converters.optional(Pct)
     )
-    rollback_ratio_last_snap: Optional[Pct] = attr.ib(
+    rollback_ratio_last_snap: Pct | None = attr.ib(
         converter=attr.converters.optional(Pct)
     )
 
     @property
-    def worker_processes(self) -> Optional[int]:
+    def worker_processes(self) -> int | None:
         if self.parallel_workers is None and self.logical_replication_workers is None:
             return None
         else:
@@ -844,24 +842,24 @@ def locktype(value: str) -> LockType:
 class BaseProcess:
     pid: int
     application_name: str
-    database: Optional[str]
+    database: str | None
     user: str
-    client: Union[None, IPv4Address, IPv6Address]
-    duration: Optional[float]
+    client: None | IPv4Address | IPv6Address
+    duration: float | None
     state: str
-    query: Optional[str]
-    encoding: Optional[str]
-    query_leader_pid: Optional[int]
+    query: str | None
+    encoding: str | None
+    query_leader_pid: int | None
     is_parallel_worker: bool
 
     _P = TypeVar("_P", bound="BaseProcess")
 
     @classmethod
     def from_bytes(
-        cls: Type[_P],
+        cls: type[_P],
         server_encoding: bytes,
         *,
-        encoding: Optional[Union[str, bytes]],
+        encoding: str | bytes | None,
         **kwargs: Any,
     ) -> _P:
         if encoding is None:
@@ -880,8 +878,8 @@ class BaseProcess:
 class RunningProcess(BaseProcess):
     """Process for a running query."""
 
-    wait: Union[bool, None, str]
-    query_leader_pid: Optional[int]
+    wait: bool | None | str
+    query_leader_pid: int | None
     is_parallel_worker: bool
 
 
@@ -896,7 +894,7 @@ class WaitingProcess(BaseProcess):
     relation: str
 
     # TODO: update queries to select/compute these column.
-    query_leader_pid: Optional[int] = attr.ib(default=None, init=False)
+    query_leader_pid: int | None = attr.ib(default=None, init=False)
     is_parallel_worker: bool = attr.ib(default=False, init=False)
 
 
@@ -909,26 +907,26 @@ class BlockingProcess(BaseProcess):
     mode: str
     type: LockType = attr.ib(converter=locktype)
     relation: str
-    wait: Union[bool, None, str]
+    wait: bool | None | str
 
     # TODO: update queries to select/compute these column.
-    query_leader_pid: Optional[int] = attr.ib(default=None, init=False)
+    query_leader_pid: int | None = attr.ib(default=None, init=False)
     is_parallel_worker: bool = attr.ib(default=False, init=False)
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class SystemProcess:
-    meminfo: Tuple[int, ...]
+    meminfo: tuple[int, ...]
     io_read: IOCounter
     io_write: IOCounter
     io_time: float
     mem_percent: float
     cpu_percent: float
-    cpu_times: Tuple[float, ...]
+    cpu_times: tuple[float, ...]
     read_delta: float
     write_delta: float
     io_wait: bool
-    psutil_proc: Optional[psutil.Process]
+    psutil_proc: psutil.Process | None
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -941,8 +939,8 @@ class LocalRunningProcess(RunningProcess):
 
     @classmethod
     def from_process(
-        cls, process: RunningProcess, **kwargs: Union[float, str]
-    ) -> "LocalRunningProcess":
+        cls, process: RunningProcess, **kwargs: float | str
+    ) -> LocalRunningProcess:
         return cls(**dict(attr.asdict(process), **kwargs))
 
 
@@ -1047,8 +1045,8 @@ class SelectableProcesses:
 
     """
 
-    items: List[BaseProcess]
-    focused: Optional[int] = None
+    items: list[BaseProcess]
+    focused: int | None = None
     pinned: MutableSet[int] = attr.ib(default=attr.Factory(set))
 
     def __len__(self) -> int:
@@ -1061,15 +1059,13 @@ class SelectableProcesses:
     def __getitem__(self, i: int) -> BaseProcess: ...
 
     @overload
-    def __getitem__(self, s: slice) -> List[BaseProcess]: ...
+    def __getitem__(self, s: slice) -> list[BaseProcess]: ...
 
-    def __getitem__(
-        self, val: Union[int, slice]
-    ) -> Union[BaseProcess, List[BaseProcess]]:
+    def __getitem__(self, val: int | slice) -> BaseProcess | list[BaseProcess]:
         return self.items[val]
 
     @property
-    def selected(self) -> List[int]:
+    def selected(self) -> list[int]:
         if self.pinned:
             return list(self.pinned)
         elif self.focused:
@@ -1084,7 +1080,7 @@ class SelectableProcesses:
     def set_items(self, new_items: Sequence[BaseProcess]) -> None:
         self.items[:] = list(new_items)
 
-    def position(self) -> Optional[int]:
+    def position(self) -> int | None:
         if self.focused is None:
             return None
         for idx, proc in enumerate(self.items):

--- a/pgactivity/ui.py
+++ b/pgactivity/ui.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import time
 from argparse import Namespace
 from functools import partial
-from typing import Dict, List, Optional, cast
+from typing import List, cast
 
 import attr
 from blessed import Terminal
@@ -13,15 +15,15 @@ from .data import Data
 
 def main(
     term: Terminal,
-    config: Optional[Configuration],
+    config: Configuration | None,
     data: Data,
     host: types.Host,
     options: Namespace,
     *,
     render_header: bool = True,
     render_footer: bool = True,
-    width: Optional[int] = None,
-    wait_on_actions: Optional[float] = None,
+    width: int | None = None,
+    wait_on_actions: float | None = None,
 ) -> None:
     fs_blocksize = options.blocksize
 
@@ -52,7 +54,7 @@ def main(
     )
 
     key, in_help = None, False
-    sys_procs: Dict[int, types.SystemProcess] = {}
+    sys_procs: dict[int, types.SystemProcess] = {}
     pg_procs = types.SelectableProcesses([])
     activity_stats: types.ActivityStats
 

--- a/pgactivity/ui.py
+++ b/pgactivity/ui.py
@@ -40,6 +40,11 @@ def main(
 
     flag = Flag.load(config, is_local=is_local, **vars(options))
     ui = types.UI.make(
+        header=types.UIHeader(
+            show_instance=options.header_show_instance,
+            show_system=options.header_show_system,
+            show_workers=options.header_show_workers,
+        ),
         config=config,
         flag=flag,
         refresh_time=options.refresh,
@@ -48,9 +53,6 @@ def main(
         wrap_query=options.wrap_query,
         max_db_length=min(max(server_information.max_dbname_length, 8), 16),
         filters=data.filters,
-        show_instance_info_in_header=options.show_instance_info_in_header,
-        show_worker_info_in_header=options.show_worker_info_in_header,
-        show_system_info_in_header=options.show_system_info_in_header,
     )
 
     key, in_help = None, False
@@ -97,12 +99,12 @@ def main(
                 elif key.name == keys.CANCEL_SELECTION:
                     pg_procs.reset()
                     ui.end_interactive()
-                elif keys.is_toggle_header_sys_info(key):
-                    ui.toggle_system_info_in_header()
-                elif keys.is_toggle_header_inst_info(key):
-                    ui.toggle_instance_info_in_header()
-                elif keys.is_toggle_header_worker_info(key):
-                    ui.toggle_worker_info_in_header()
+                elif keys.is_toggle_header_system(key):
+                    ui.header.toggle_system()
+                elif keys.is_toggle_header_instance(key):
+                    ui.header.toggle_instance()
+                elif keys.is_toggle_header_workers(key):
+                    ui.header.toggle_workers()
                 elif pg_procs.selected and key in (
                     keys.PROCESS_CANCEL,
                     keys.PROCESS_KILL,

--- a/pgactivity/ui.py
+++ b/pgactivity/ui.py
@@ -40,7 +40,8 @@ def main(
 
     flag = Flag.load(config, is_local=is_local, **vars(options))
     ui = types.UI.make(
-        header=types.UIHeader(
+        header=types.UIHeader.make(
+            config.header() if config else None,
             show_instance=options.header_show_instance,
             show_system=options.header_show_system,
             show_workers=options.header_show_workers,

--- a/pgactivity/utils.py
+++ b/pgactivity/utils.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import functools
 import re
 from datetime import datetime, timedelta
-from typing import IO, Any, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import IO, Any, Iterable, Mapping
 
 import attr
 import humanize
@@ -49,12 +51,12 @@ class MessagePile:
     """
 
     n: int
-    messages: List[str] = attr.ib(default=attr.Factory(list), init=False)
+    messages: list[str] = attr.ib(default=attr.Factory(list), init=False)
 
     def send(self, message: str) -> None:
         self.messages[:] = [message] * self.n
 
-    def get(self) -> Optional[str]:
+    def get(self) -> str | None:
         if self.messages:
             return self.messages.pop()
         return None
@@ -106,7 +108,7 @@ def ellipsis(v: str, width: int) -> str:
     return v[: wl + 1] + "..." + v[-wl:]
 
 
-def get_duration(duration: Optional[float]) -> float:
+def get_duration(duration: float | None) -> float:
     """Return 0 if the given duration is negative else, return the duration.
 
     >>> get_duration(None)
@@ -122,7 +124,7 @@ def get_duration(duration: Optional[float]) -> float:
 
 
 @functools.lru_cache(maxsize=2)
-def format_duration(duration: Optional[float]) -> Tuple[str, str]:
+def format_duration(duration: float | None) -> tuple[str, str]:
     """Return a string from 'duration' value along with the color for rendering.
 
     >>> format_duration(None)
@@ -165,7 +167,7 @@ def format_duration(duration: Optional[float]) -> Tuple[str, str]:
     return ctime, color
 
 
-def wait_status(value: Union[None, bool, str]) -> str:
+def wait_status(value: None | bool | str) -> str:
     """Display the waiting status of query.
 
     >>> wait_status(None)
@@ -272,7 +274,7 @@ def csv_write(
             + "\n"
         )
 
-    def yn_na(value: Optional[bool]) -> str:
+    def yn_na(value: bool | None) -> str:
         if value is None:
             return "N/A"
         return yn(value)

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -4,13 +4,13 @@ import functools
 import inspect
 import itertools
 from textwrap import TextWrapper, dedent
-from typing import Any, Callable, Iterable, Iterator, Sequence
+from typing import Any
 
 from blessed import Terminal
 
 from . import colors, utils
 from .activities import sorted as sorted_processes
-from .compat import link
+from .compat import Callable, Iterable, Iterator, Sequence, link
 from .keys import BINDINGS, EXIT_KEY
 from .keys import HELP as HELP_KEY
 from .keys import (

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import functools
 import inspect
 import itertools
 from textwrap import TextWrapper, dedent
-from typing import Any, Callable, Iterable, Iterator, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Iterable, Iterator, Sequence
 
 from blessed import Terminal
 
@@ -47,7 +49,7 @@ class line_counter:
 
 
 @functools.lru_cache(maxsize=512)
-def shorten(term: Terminal, text: str, width: Optional[int] = None) -> str:
+def shorten(term: Terminal, text: str, width: int | None = None) -> str:
     r"""Truncate 'text' to fit in the given 'width' (or term.width).
 
     This is similar to textwrap.shorten() but sequence-aware.
@@ -157,7 +159,7 @@ def header(
     host: Host,
     pg_version: str,
     server_information: ServerInformation,
-    system_info: Optional[SystemInfo] = None,
+    system_info: SystemInfo | None = None,
 ) -> Iterator[str]:
     @functools.singledispatch
     def render(x: Any) -> str:
@@ -188,7 +190,7 @@ def header(
         return f"{term.bold_green(hbytes)} - {term.bold_green(counts)}"
 
     def render_columns(
-        columns: Sequence[List[str]], *, delimiter: str = f"{term.blue(',')} "
+        columns: Sequence[list[str]], *, delimiter: str = f"{term.blue(',')} "
     ) -> Iterator[str]:
         column_widths = [
             max(len(column_row) for column_row in column) for column in columns
@@ -402,7 +404,7 @@ def processes_rows(
     ui: UI,
     processes: SelectableProcesses,
     maxlines: int,
-    width: Optional[int],
+    width: int | None,
 ) -> Iterator[str]:
     """Display table rows with processes information."""
 
@@ -449,7 +451,7 @@ def processes_rows(
             color_type = "yellow"
         else:
             color_type = "default"
-        text: List[str] = []
+        text: list[str] = []
         for column in ui.columns():
             field = column.key
             if field != "query":
@@ -472,13 +474,13 @@ def processes_rows(
         yield from (" ".join(text) + term.normal).splitlines()
 
 
-def footer_message(term: Terminal, message: str, width: Optional[int] = None) -> None:
+def footer_message(term: Terminal, message: str, width: int | None = None) -> None:
     if width is None:
         width = term.width
     print(term.center(message[:width]) + term.normal, end="")
 
 
-def footer_help(term: Terminal, width: Optional[int] = None) -> None:
+def footer_help(term: Terminal, width: int | None = None) -> None:
     """Footer line with help keys."""
     query_modes_help = [
         ("/".join(keys[:-1]), qm.value) for qm, keys in KEYS_BY_QUERYMODE.items()
@@ -493,7 +495,7 @@ def footer_help(term: Terminal, width: Optional[int] = None) -> None:
 
 
 def render_footer(
-    term: Terminal, footer_values: List[Tuple[str, str]], width: Optional[int]
+    term: Terminal, footer_values: list[tuple[str, str]], width: int | None
 ) -> None:
     if width is None:
         width = term.width
@@ -514,7 +516,7 @@ def render_footer(
     print(term.ljust(row, width=width, fillchar=term.cyan_reverse(" ")), end="")
 
 
-def footer_interative_help(term: Terminal, width: Optional[int] = None) -> None:
+def footer_interative_help(term: Terminal, width: int | None = None) -> None:
     """Footer line with help keys for interactive mode."""
     assert PROCESS_PIN.name is not None
     footer_values = [
@@ -535,14 +537,14 @@ def screen(
     pg_version: str,
     server_information: ServerInformation,
     activity_stats: ActivityStats,
-    message: Optional[str],
+    message: str | None,
     render_header: bool = True,
     render_footer: bool = True,
-    width: Optional[int] = None,
+    width: int | None = None,
 ) -> None:
     """Display the screen."""
 
-    system_info: Optional[SystemInfo]
+    system_info: SystemInfo | None
     if isinstance(activity_stats, tuple):
         processes, system_info = activity_stats
     else:

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -232,7 +232,7 @@ def header(
     size_ev = f"{utils.naturalsize(si.size_evolution)}/s"
     uptime = utils.naturaltimedelta(si.uptime)
 
-    if ui.show_instance_info_in_header:
+    if ui.header.show_instance:
         # First rows are always displayed, as the underlying data is always available.
         columns = [
             [f"* Global: {render(uptime)} uptime"],
@@ -268,7 +268,7 @@ def header(
             [f"{render(temp_size)} temp size"],
         ]
         yield from render_columns(columns)
-    if ui.show_worker_info_in_header:
+    if ui.header.show_workers:
         columns = [
             [
                 f"* Worker processes: {render(si.worker_processes)}/{render(si.max_worker_processes)} total"
@@ -295,7 +295,7 @@ def header(
         yield from render_columns(columns)
 
     # System information, only available in "local" mode.
-    if system_info is not None and ui.show_system_info_in_header:
+    if system_info is not None and ui.header.show_system:
         used, bc, free, total = (
             utils.naturalsize(system_info.memory.used),
             utils.naturalsize(system_info.memory.buff_cached),

--- a/pgactivity/widgets.py
+++ b/pgactivity/widgets.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from blessed import Terminal
 
@@ -10,7 +10,7 @@ def boxed(
     border: bool = True,
     border_color: str = "white",
     center: bool = False,
-    width: Optional[int] = None,
+    width: int | None = None,
 ) -> str:
     if border:
         border_width = term.length(content) + 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "flake8",
     "isort",
     "pre-commit",
+    "pyupgrade",
 ]
 typing = [
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Command line tool for PostgreSQL server activity monitoring."
 readme = "README.md"
 license = { text = "PostgreSQL" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Julien Tachoires", email = "julmon@gmail.com" },
     { name = "Benoit Lobréau", email = "benoit.lobreau@dalibo.com" },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 import pathlib
 import threading
-from typing import Any, List, Optional
+from typing import Any
 
 import psycopg
 import psycopg.errors
@@ -15,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 
 
-def pytest_report_header(config: Any) -> List[str]:
+def pytest_report_header(config: Any) -> list[str]:
     return [f"psycopg: {pg.__version__}"]
 
 
@@ -28,7 +30,7 @@ def datadir() -> pathlib.Path:
 def database_factory(postgresql):
     dbnames = set()
 
-    def createdb(dbname: str, encoding: str, locale: Optional[str] = None) -> None:
+    def createdb(dbname: str, encoding: str, locale: str | None = None) -> None:
         with psycopg.connect(postgresql.info.dsn, autocommit=True) as conn:
             qs = sql.SQL(
                 "CREATE DATABASE {dbname} ENCODING {encoding} TEMPLATE template0"
@@ -67,7 +69,7 @@ def execute(postgresql):
         query: str,
         commit: bool = False,
         autocommit: bool = False,
-        dbname: Optional[str] = None,
+        dbname: str | None = None,
     ) -> None:
         dsn, kwargs = postgresql.info.dsn, {}
         if dbname:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import attr
 
@@ -75,7 +77,7 @@ def test_flag_load():
 
 
 def test_lookup(tmp_path: Path) -> None:
-    def asdict(cfg: Configuration) -> Dict[str, Any]:
+    def asdict(cfg: Configuration) -> dict[str, Any]:
         return {k: attr.asdict(v) for k, v in cfg.items()}
 
     cfg = Configuration.lookup(user_config_home=tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,6 +83,18 @@ def test_lookup(tmp_path: Path) -> None:
     cfg = Configuration.lookup(user_config_home=tmp_path)
     assert cfg is None
 
-    (tmp_path / "pg_activity.conf").write_text("\n".join(["[client]", "width=5"]))
+    (tmp_path / "pg_activity.conf").write_text(
+        "\n".join(
+            [
+                "[client]",
+                "width=5",
+                "[header]",
+                "show_instance=no",
+            ]
+        )
+    )
     cfg = Configuration.lookup(user_config_home=tmp_path)
-    assert cfg is not None and asdict(cfg) == {"client": {"hidden": False, "width": 5}}
+    assert cfg is not None and asdict(cfg) == {
+        "client": {"hidden": False, "width": 5},
+        "header": {"show_instance": False, "show_system": True, "show_workers": True},
+    }

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import time
-from typing import Optional
 
 import attr
 import psycopg
@@ -163,7 +164,7 @@ def test_client_encoding(postgresql, encoding: str) -> None:
     ],
 )
 def test_postgres_and_python_encoding(
-    database_factory, pyenc: str, pgenc: str, locale: Optional[str], data, postgresql
+    database_factory, pyenc: str, pgenc: str, locale: str | None, data, postgresql
 ) -> None:
     dbname = pyenc
     try:

--- a/tests/test_ui.txt
+++ b/tests/test_ui.txt
@@ -46,9 +46,9 @@ Default CLI options, passed to ui.main():
 ...     "rds": False,
 ...     "username": f"{postgres.info.user}",
 ...     "wrap_query": False,
-...     "show_instance_info_in_header": True,
-...     "show_worker_info_in_header": True,
-...     "show_system_info_in_header": True,
+...     "header_show_instance": True,
+...     "header_show_workers": True,
+...     "header_show_system": True,
 ... }
 >>> options = argparse.Namespace(**defaults)
 
@@ -428,9 +428,9 @@ PID    DATABASE              USER       CLIENT             state Query
 ------------------------------------------------------------------------------------------- sending key 'q' --------------------------------------------------------------------------------------------
 
 >>> defaults["nopid"] = True
->>> defaults["show_instance_info_in_header"] = False
->>> defaults["show_worker_info_in_header"] = False
->>> defaults["show_system_info_in_header"] = False
+>>> defaults["header_show_instance"] = False
+>>> defaults["header_show_workers"] = False
+>>> defaults["header_show_system"] = False
 >>> options = argparse.Namespace(**defaults)
 
 One query, idle in transaction:

--- a/tests/test_views.txt
+++ b/tests/test_views.txt
@@ -158,7 +158,7 @@ PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mo
    IO: 300/s max iops, 200B/s - 100/s read, 300B/s - 200/s write
    Load average: 1 5 15
 
->>> ui.toggle_system_info_in_header()
+>>> ui.header.toggle_system()
 >>> header(term, ui, host=host, server_information=serverinfo,
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)
@@ -170,8 +170,8 @@ PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mo
    Other processes & info: 3/3 autovacuum workers, 1/10 wal senders, 0 wal receivers, 10/10 repl. slots
 
 >>> ui = UI.make(refresh_time=10, duration_mode=DurationMode.query)
->>> ui.toggle_system_info_in_header()
->>> ui.toggle_worker_info_in_header()
+>>> ui.header.toggle_system()
+>>> ui.header.toggle_workers()
 >>> header(term, ui, host=host, server_information=serverinfo,
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)
@@ -181,9 +181,9 @@ PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 10s - Duration mo
    Activity: 15 tps, 10 insert/s, 20 update/s, 30 delete/s, 40 tuples returned/s, 5 temp files, 11.50M temp size
 
 >>> ui = UI.make(refresh_time=2, min_duration=1.2, duration_mode=DurationMode.transaction)
->>> ui.toggle_system_info_in_header()
->>> ui.toggle_worker_info_in_header()
->>> ui.toggle_instance_info_in_header()
+>>> ui.header.toggle_system()
+>>> ui.header.toggle_workers()
+>>> ui.header.toggle_instance()
 >>> header(term, ui, host=host, server_information=serverinfo,
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)
@@ -196,7 +196,7 @@ PostgreSQL 9.6 - localhost - tester@host:5432/postgres - Ref.: 2s - Duration mod
 ...     io_read=IOCounter(0,0),
 ...     io_write=IOCounter(0,0),
 ...     max_iops=0)
->>> ui.toggle_system_info_in_header()
+>>> ui.header.toggle_system()
 >>> header(term, ui, host=host, server_information=serverinfo,
 ...        system_info=sysinfo, pg_version="PostgreSQL 9.6",
 ...        width=200)

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,14 @@ deps =
     black >= 24.2.0
     flake8
     isort
+    pre-commit
+    pyupgrade
 commands =
     codespell {toxinidir}
     black --check --diff {toxinidir}
     flake8 {toxinidir}
     isort --check --diff {toxinidir}
+    pre-commit run --all-files --show-diff-on-failure pyupgrade
 
 [testenv:mypy]
 extras =


### PR DESCRIPTION
This stems from the idea discussed at https://github.com/dalibo/pg_activity/pull/387#issuecomment-1623178466.#396.

```
$ cat ~/.config/pg_activity/my.conf 
[database]
hidden = true
```
```
$ pg_activity --profile my  # will use the file above as configuration
```

One thing I wonder is whether the option should be named `--config <full-path-to-config>` or if we should introduce another option later on.

* * *

Based on #404 