### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.7"
+          - python: "3.8"
             psycopg: "psycopg2"
           - python: "3.12"
             psycopg: "psycopg3"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
         exclude: tests/test_*.txt
   - repo: local
     hooks:
+      - id: pyupgrade
+        name: pyupgrade
+        entry: pyupgrade --py38-plus --exit-zero-even-if-changed
+        language: system
+        types: [python]
       - id: black
         name: black
         entry: black --check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * Fix retrieval of I/O statistics on BSD systems (#393).
 * Fix spelling mistakes in the man page.
 
+### Removed
+
+* Python 3.7 is no longer supported.
+
 ### Misc
 
 * Document how to *hack* on pg\_activity in the `README`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pg\_activity releases. Before submitting a bug report here:
 
 ## From PyPI
 
-pg\_activity can be installed using pip on Python 3.7 or later along with
+pg\_activity can be installed using pip on Python 3.8 or later along with
 psycopg:
 
     $ python3 -m pip install "pg_activity[psycopg]"

--- a/pgactivity/compat.py
+++ b/pgactivity/compat.py
@@ -1,15 +1,10 @@
 import operator
-import sys
+from importlib.metadata import version
 from typing import Any, Dict
 
 import attr
 import attr.validators
 import blessed
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
 
 ATTR_VERSION = tuple(int(x) for x in version("attrs").split(".", 2)[:2])
 BLESSED_VERSION = tuple(int(x) for x in version("blessed").split(".", 2)[:2])

--- a/pgactivity/types.py
+++ b/pgactivity/types.py
@@ -278,7 +278,7 @@ class UI:
                 key="database",
                 name="DATABASE(*)" if filters.dbname else "DATABASE",
                 min_width=max_db_length,
-                transform=functools.lru_cache()(
+                transform=functools.lru_cache(
                     lambda v: utils.ellipsis(v, width=16) if v else "",
                 ),
                 sort_key=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "flake8",
     "isort",
     "pre-commit",
+    "pyupgrade",
 ]
 typing = [
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Command line tool for PostgreSQL server activity monitoring."
 readme = "README.md"
 license = { text = "PostgreSQL" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Julien Tachoires", email = "julmon@gmail.com" },
     { name = "Benoit Lobréau", email = "benoit.lobreau@dalibo.com" },

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,14 @@ deps =
     black >= 24.2.0
     flake8
     isort
+    pre-commit
+    pyupgrade
 commands =
     codespell {toxinidir}
     black --check --diff {toxinidir}
     flake8 {toxinidir}
     isort --check --diff {toxinidir}
+    pre-commit run --all-files --show-diff-on-failure pyupgrade
 
 [testenv:mypy]
 extras =


### PR DESCRIPTION
This version has reached its end-of-life last year, https://peps.python.org/pep-0537/#lifespan.