### PR TITLE
Enable back setuptools automatic discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Resolve a warning about usage of a deprecated Python `datetime` API from
   Python 3.12.
+* Resolve setuptools warnings about packages 'pgactivity.profiles' and
+  'pgactivity.queries' being absent from `packages` configuration by getting
+  back to setuptools "automatic discovery" (#411).
 
 ### Misc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,6 @@ Homepage = "https://github.com/dalibo/pg_activity"
 [tool.setuptools.dynamic]
 version = { attr = "pgactivity.__version__" }
 
-[tool.setuptools]
-packages = ["pgactivity"]
-
 [tool.black]
 line-length = 88
 include = '\.pyi?$'


### PR DESCRIPTION
Fix #411 

@asarubbo, can you check if this resolves #411 on Gentoo?
@mikelolasagasti, can you check if this change works for Fedora, as this reverts the one from #378?