### PR TITLE
Fix bad date format for datetimeutc field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 * Fix configuration of the color of `appname` column (#415).
+* Fix `datetimeutc` column in CSV export showing wrong "minutes" value (#429).
 
 ### Changed
 

--- a/pgactivity/utils.py
+++ b/pgactivity/utils.py
@@ -290,7 +290,7 @@ def csv_write(
         return yn(value)
 
     for p in procs:
-        dt = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%m:%SZ")
+        dt = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         pid = p.get("pid", "N/A")
         database = p.get("database", "N/A") or ""
         appname = p.get("application_name", "N/A")


### PR DESCRIPTION
Hello,

A client saw a problem with datetimeutc field using `pg_activity --output`. Here is a fix.
Instead of minutes, month was displayed.

Closes #430
Regards,