### PR TITLE
Avoid humanize 4.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
     "attrs >= 17.4, !=21.1",
     "blessed >= 1.15.0",
-    "humanize >= 0.5.1",
+    "humanize >= 0.5.1, !=4.12.0",
     "psutil >= 2.0.0",
 ]
 


### PR DESCRIPTION
We are apparently affected by this issue:

  https://github.com/python-humanize/humanize/issues/239

Let's avoid that version and wait for a fix.