### PR TITLE
Disable log_statements when --hide-queries-in-logs is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Unreleased 
+
+### Fixed
+
+*  Fix `--hide-queries-in-logs` to also disable log_statements when it is used
+   (Kouber Saparev).
+
 ## pg\_activity 3.6.0 - 2025-02-21
 
 ### Added

--- a/pgactivity/data.py
+++ b/pgactivity/data.py
@@ -101,6 +101,7 @@ class Data:
         )
         if hide_queries_in_logs:
             pg.execute(pg_conn, queries.get("disable_log_min_duration_statement"))
+            pg.execute(pg_conn, queries.get("disable_log_statement"))
             if pg.server_version(pg_conn) >= 130000:
                 pg.execute(pg_conn, queries.get("disable_log_min_duration_sample"))
         pg_version = pg_get_short_version(pg_get_version(pg_conn))

--- a/pgactivity/queries/disable_log_statement.sql
+++ b/pgactivity/queries/disable_log_statement.sql
@@ -1,0 +1,1 @@
+  SET log_statement TO 'none';


### PR DESCRIPTION
We only disable log_min_duration_statement and log_min_duration_sample. when --hide-queries-in-logs which leaves us with tracs from log_statements. This aptch fixes that.

Authored by Kouber Saparev