### PR TITLE
Fix tests on --help when invoked through 'python -m pytest'

### DIFF
--- a/pgactivity/cli.py
+++ b/pgactivity/cli.py
@@ -56,8 +56,9 @@ def flag(p: Any, spec: str, *, dest: str, feature: str) -> None:
     )
 
 
-def get_parser() -> argparse.ArgumentParser:
+def get_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
+        prog=prog,
         usage="%(prog)s [options] [connection string]",
         description=(
             "htop like application for PostgreSQL server activity monitoring."

--- a/tests/test_cli_help.txt
+++ b/tests/test_cli_help.txt
@@ -5,9 +5,9 @@
 ...
 
 >>> from pgactivity import cli
->>> parser = cli.get_parser()
+>>> parser = cli.get_parser(prog="pg_activity")
 >>> parser.print_help()
-usage: pytest [options] [connection string]
+usage: pg_activity [options] [connection string]
 <BLANKLINE>
 htop like application for PostgreSQL server activity monitoring.
 <BLANKLINE>

--- a/tests/test_cli_help_py312.txt
+++ b/tests/test_cli_help_py312.txt
@@ -5,9 +5,9 @@
 ...
 
 >>> from pgactivity import cli
->>> parser = cli.get_parser()
+>>> parser = cli.get_parser(prog="pg_activity")
 >>> parser.print_help()
-usage: pytest [options] [connection string]
+usage: pg_activity [options] [connection string]
 <BLANKLINE>
 htop like application for PostgreSQL server activity monitoring.
 <BLANKLINE>


### PR DESCRIPTION
The 'prog' value of argparse.ArgumentParser() depends on sys.argv[0]. We assumed 'pytest' in test_cli_help*.txt, but this could be 'python -m pytest' as well. Add a way to fix this value when creating the parser so that this is predictable in our tests.

Fix #435.