### PR TITLE
Fix return type annotation of BytesLoader.load()

### DIFF
--- a/pgactivity/pg.py
+++ b/pgactivity/pg.py
@@ -31,7 +31,7 @@ try:
     Connection = psycopg.Connection[dict[str, Any]]
 
     class BytesLoader(Loader):
-        def load(self, data: Buffer) -> bytes:
+        def load(self, data: Buffer) -> bytes | bytearray:
             if isinstance(data, memoryview):
                 return bytes(data)
             return data


### PR DESCRIPTION
Buffer may be also by a bytearray.