### PR TITLE
Fix project.license field to use a SPDX expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 *  Fix `--hide-queries-in-logs` to also disable log_statements when it is used
    (Kouber Saparev).
+* Fix deprecated syntax of the `license` field in packaging metadata; require
+  setuptools version 77.0.0 or higher accordingly.
 
 ## pg\_activity 3.6.0 - 2025-02-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools >= 77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,7 @@ name = "pg-activity"
 dynamic = ["version"]
 description = "Command line tool for PostgreSQL server activity monitoring."
 readme = "README.md"
-license = { text = "PostgreSQL" }
+license = "PostgreSQL"
 requires-python = ">=3.9"
 authors = [
     { name = "Julien Tachoires", email = "julmon@gmail.com" },
@@ -31,7 +31,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Environment :: Console :: Curses",
-    "License :: OSI Approved :: PostgreSQL License",
     "Programming Language :: Python :: 3",
     "Topic :: Database",
 ]


### PR DESCRIPTION
And accordingly remove the license classifier.

Fix #436.