### PR TITLE
Remove dummy setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
    (Kouber Saparev).
 * Fix deprecated syntax of the `license` field in packaging metadata; require
   setuptools version 77.0.0 or higher accordingly.
+* Remove dummy `setup.py` file.
 
 ## pg\_activity 3.6.0 - 2025-02-21
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
Invoking setup.py file from the command-line is deprecated and since this file does not hold any configuration it is in fact useless.