### PR TITLE
Strip commented and empty lines from SQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+### Fixed
+
+* Strip comments from SQL queries emitted by pg\_activity (#442).
+
 ## pg\_activity 3.6.1 - 2025-06-03
 
 ### Fixed

--- a/pgactivity/queries/__init__.py
+++ b/pgactivity/queries/__init__.py
@@ -6,6 +6,21 @@ here = pathlib.Path(__file__).parent
 
 @functools.cache
 def get(name: str) -> str:
+    r"""Return the SQL query contained in named file, ignoring commented lines.
+
+    >>> get('get_version')
+    'SELECT version() AS pg_version;'
+    >>> print(get('get_pg_activity_post_130000')[:101])
+    SELECT
+          a.pid AS pid,
+          a.backend_xmin AS xmin,
+          a.application_name AS application_name
+    """
     path = here / f"{name}.sql"
+    s = "-- "
     with path.open() as f:
-        return f.read()
+        return "\n".join(
+            line.rstrip().split(s, 1)[0]
+            for line in f
+            if line.strip() and not line.startswith(s)
+        )


### PR DESCRIPTION
This avoids "polluting" server logs.

A doctest for queries.get() is added along the way.

Fix #442.