### PR TITLE
Fix the behavior of Terminal.wrap() (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@
 * Strip comments from SQL queries emitted by pg\_activity (#442).
 * Remove the "tuples returned/s" metric from the header, it provided misleading 
   information (#441, reported by @kmoppel)
+* Fix a difference in wrapping behavior introduced in blessed 1.26 (#455,
+  reported by @asarubbo)
 
 ## pg\_activity 3.6.1 - 2025-06-03
 
 ### Fixed
 
-*  Fix `--hide-queries-in-logs` to also disable log_statements when it is used
-   (Kouber Saparev).
+* Fix `--hide-queries-in-logs` to also disable log_statements when it is used
+  (Kouber Saparev).
 * Fix deprecated syntax of the `license` field in packaging metadata; require
   setuptools version 77.0.0 or higher accordingly.
 * Remove dummy `setup.py` file.

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -129,12 +129,10 @@ def limit(func: Callable[..., Iterable[str]]) -> Callable[..., None]:
 def help(term: Terminal, version: str, is_local: bool) -> Iterable[str]:
     """Render help menu."""
     project_url = "https://github.com/dalibo/pg_activity"
-    intro = dedent(
-        f"""\
+    intro = dedent(f"""\
     {term.bold_green}pg_activity {version} - {link(term, project_url, project_url)}
     {term.normal}Released under PostgreSQL License.
-    """
-    )
+    """)
 
     def key_mappings(keys: Iterable[Key]) -> Iterable[str]:
         for key in keys:

--- a/pgactivity/views.py
+++ b/pgactivity/views.py
@@ -71,7 +71,7 @@ def shorten(term: Terminal, text: str, width: int | None = None) -> str:
     """
     if not text:
         return ""
-    wrapped = term.wrap(text, width=width, max_lines=1)
+    wrapped = term.wrap(text, width=width, max_lines=1, placeholder="")
     return wrapped[0] + term.normal
 
 


### PR DESCRIPTION
The behavior of Terminal.wrap() seemed to have changed in blessed 1.26. This patches forces the placeholder string to "" to fix it.

Closes #455 reported by asarubbo